### PR TITLE
Remove ParcelableEnrollment

### DIFF
--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/EnrollRequest.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/EnrollRequest.java
@@ -28,7 +28,7 @@ import com.auth0.android.guardian.sdk.networking.Callback;
 
 import java.io.IOException;
 
-class EnrollRequest implements GuardianAPIRequest<ParcelableEnrollment> {
+class EnrollRequest implements GuardianAPIRequest<Enrollment> {
 
     final GuardianAPIClient client;
     final EnrollmentData enrollmentData;
@@ -46,7 +46,7 @@ class EnrollRequest implements GuardianAPIRequest<ParcelableEnrollment> {
     }
 
     @Override
-    public ParcelableEnrollment execute() throws IOException, GuardianException {
+    public Enrollment execute() throws IOException, GuardianException {
         String deviceToken = client
                 .getDeviceToken(enrollmentData.getEnrollmentTransactionId())
                 .execute();
@@ -57,12 +57,12 @@ class EnrollRequest implements GuardianAPIRequest<ParcelableEnrollment> {
     }
 
     @Override
-    public void start(@NonNull final Callback<ParcelableEnrollment> callback) {
+    public void start(@NonNull final Callback<Enrollment> callback) {
         client.getDeviceToken(enrollmentData.getEnrollmentTransactionId())
                 .start(deviceTokenCallback(callback));
     }
 
-    private Callback<String> deviceTokenCallback(@NonNull final Callback<ParcelableEnrollment> callback) {
+    private Callback<String> deviceTokenCallback(@NonNull final Callback<Enrollment> callback) {
         return new Callback<String>() {
             @Override
             public void onSuccess(String deviceToken) {
@@ -79,11 +79,11 @@ class EnrollRequest implements GuardianAPIRequest<ParcelableEnrollment> {
     }
 
     private Callback<Device> createDeviceCallback(@NonNull final String deviceToken,
-                                                  @NonNull final Callback<ParcelableEnrollment> callback) {
+                                                  @NonNull final Callback<Enrollment> callback) {
         return new Callback<Device>() {
             @Override
             public void onSuccess(Device device) {
-                ParcelableEnrollment enrollment = createEnrollment(device, deviceToken);
+                Enrollment enrollment = createEnrollment(device, deviceToken);
                 callback.onSuccess(enrollment);
             }
 
@@ -94,8 +94,8 @@ class EnrollRequest implements GuardianAPIRequest<ParcelableEnrollment> {
         };
     }
 
-    private ParcelableEnrollment createEnrollment(@NonNull Device device, @NonNull String deviceToken) {
-        return new ParcelableEnrollment(client.getUrl(), enrollmentData.getIssuer(),
+    private Enrollment createEnrollment(@NonNull Device device, @NonNull String deviceToken) {
+        return new GuardianEnrollment(client.getUrl(), enrollmentData.getIssuer(),
                 enrollmentData.getUser(), enrollmentData.getPeriod(), enrollmentData.getDigits(),
                 enrollmentData.getAlgorithm(), enrollmentData.getSecret(), device.getEnrollmentId(),
                 device.getDeviceIdentifier(), device.getDeviceName(), device.getGCMToken(), deviceToken);

--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -58,7 +58,7 @@ public class Guardian implements Parcelable {
      *                                  uri
      */
     @NonNull
-    public GuardianAPIRequest<ParcelableEnrollment> enroll(@NonNull Uri enrollmentUri,
+    public GuardianAPIRequest<Enrollment> enroll(@NonNull Uri enrollmentUri,
                                                            @NonNull String deviceName,
                                                            @NonNull String gcmToken) {
         EnrollmentData enrollmentData = EnrollmentData.parse(enrollmentUri);

--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianEnrollment.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianEnrollment.java
@@ -22,14 +22,11 @@
 
 package com.auth0.android.guardian.sdk;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-
-public class ParcelableEnrollment implements Enrollment, Parcelable {
+class GuardianEnrollment implements Enrollment {
 
     private final String id;
     private final String url;
-    private final String tenant;
+    private final String label;
     private final String user;
     private final int period;
     private final int digits;
@@ -40,20 +37,20 @@ public class ParcelableEnrollment implements Enrollment, Parcelable {
     private final String deviceGCMToken;
     private final String deviceToken;
 
-    ParcelableEnrollment(String url,
-                         String tenant,
-                         String user,
-                         int period,
-                         int digits,
-                         String algorithm,
-                         String secret,
-                         String deviceId,
-                         String deviceIdentifier,
-                         String deviceName,
-                         String deviceGCMToken,
-                         String deviceToken) {
+    GuardianEnrollment(String url,
+                       String label,
+                       String user,
+                       int period,
+                       int digits,
+                       String algorithm,
+                       String secret,
+                       String deviceId,
+                       String deviceIdentifier,
+                       String deviceName,
+                       String deviceGCMToken,
+                       String deviceToken) {
         this.url = url;
-        this.tenant = tenant;
+        this.label = label;
         this.user = user;
         this.period = period;
         this.digits = digits;
@@ -78,7 +75,7 @@ public class ParcelableEnrollment implements Enrollment, Parcelable {
 
     @Override
     public String getLabel() {
-        return tenant;
+        return label;
     }
 
     @Override
@@ -125,54 +122,4 @@ public class ParcelableEnrollment implements Enrollment, Parcelable {
     public String getDeviceToken() {
         return deviceToken;
     }
-
-    // PARCELABLE
-    protected ParcelableEnrollment(Parcel in) {
-        id = in.readString();
-        url = in.readString();
-        tenant = in.readString();
-        user = in.readString();
-        period = in.readInt();
-        digits = in.readInt();
-        algorithm = in.readString();
-        secret = in.readString();
-        deviceIdentifier = in.readString();
-        deviceName = in.readString();
-        deviceGCMToken = in.readString();
-        deviceToken = in.readString();
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(id);
-        dest.writeString(url);
-        dest.writeString(tenant);
-        dest.writeString(user);
-        dest.writeInt(period);
-        dest.writeInt(digits);
-        dest.writeString(algorithm);
-        dest.writeString(secret);
-        dest.writeString(deviceIdentifier);
-        dest.writeString(deviceName);
-        dest.writeString(deviceGCMToken);
-        dest.writeString(deviceToken);
-    }
-
-    @SuppressWarnings("unused")
-    public static final Parcelable.Creator<ParcelableEnrollment> CREATOR = new Parcelable.Creator<ParcelableEnrollment>() {
-        @Override
-        public ParcelableEnrollment createFromParcel(Parcel in) {
-            return new ParcelableEnrollment(in);
-        }
-
-        @Override
-        public ParcelableEnrollment[] newArray(int size) {
-            return new ParcelableEnrollment[size];
-        }
-    };
 }

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/EnrollRequestTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/EnrollRequestTest.java
@@ -82,7 +82,7 @@ public class EnrollRequestTest {
     GuardianAPIClient apiClient;
 
     @Mock
-    Callback<ParcelableEnrollment> enrollmentCallback;
+    Callback<Enrollment> enrollmentCallback;
 
     @Captor
     ArgumentCaptor<Callback<String>> deviceTokenCallbackCaptor;
@@ -91,7 +91,7 @@ public class EnrollRequestTest {
     ArgumentCaptor<Callback<Device>> deviceCallbackCaptor;
 
     @Captor
-    ArgumentCaptor<ParcelableEnrollment> enrollmentCaptor;
+    ArgumentCaptor<Enrollment> enrollmentCaptor;
 
     @Captor
     ArgumentCaptor<Throwable> throwableCaptor;
@@ -146,7 +146,7 @@ public class EnrollRequestTest {
 
     @Test
     public void shouldEnrollSucessfullySync() throws Exception {
-        ParcelableEnrollment enrollment = enrollRequest
+        Enrollment enrollment = enrollRequest
                 .execute();
 
         assertThat(enrollment.getUrl(), is(equalTo(GUARDIAN_URL)));
@@ -178,7 +178,7 @@ public class EnrollRequestTest {
 
         verify(enrollmentCallback).onSuccess(enrollmentCaptor.capture());
 
-        ParcelableEnrollment enrollment = enrollmentCaptor.getValue();
+        Enrollment enrollment = enrollmentCaptor.getValue();
 
         assertThat(enrollment.getUrl(), is(equalTo(GUARDIAN_URL)));
         assertThat(enrollment.getLabel(), is(equalTo(TENANT)));

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianEnrollmentTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianEnrollmentTest.java
@@ -22,21 +22,13 @@
 
 package com.auth0.android.guardian.sdk;
 
-import android.os.Bundle;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
-public class ParcelableEnrollmentTest {
+public class GuardianEnrollmentTest {
 
     private static final String URL_HTTP_WITH_FINAL_DASH = "http://example.com/";
     private static final String TENANT = "TENANT";
@@ -53,35 +45,9 @@ public class ParcelableEnrollmentTest {
 
     @Test
     public void shouldHaveCorrectData() throws Exception {
-        ParcelableEnrollment enrollment = new ParcelableEnrollment(URL_HTTP_WITH_FINAL_DASH, TENANT, USER, PERIOD,
+        Enrollment enrollment = new GuardianEnrollment(URL_HTTP_WITH_FINAL_DASH, TENANT, USER, PERIOD,
                 DIGITS, ALGORITHM, SECRET_BASE32, DEVICE_ID, DEVICE_LOCAL_IDENTIFIER, DEVICE_NAME,
                 DEVICE_GCM_TOKEN, DEVICE_TOKEN);
-        assertThat(enrollment.getUrl(), is(equalTo(URL_HTTP_WITH_FINAL_DASH)));
-        assertThat(enrollment.getLabel(), is(equalTo(TENANT)));
-        assertThat(enrollment.getUser(), is(equalTo(USER)));
-        assertThat(enrollment.getPeriod(), is(equalTo(PERIOD)));
-        assertThat(enrollment.getDigits(), is(equalTo(DIGITS)));
-        assertThat(enrollment.getAlgorithm(), is(equalTo(ALGORITHM)));
-        assertThat(enrollment.getSecret(), is(equalTo(SECRET_BASE32)));
-        assertThat(enrollment.getId(), is(equalTo(DEVICE_ID)));
-        assertThat(enrollment.getDeviceIdentifier(), is(equalTo(DEVICE_LOCAL_IDENTIFIER)));
-        assertThat(enrollment.getDeviceName(), is(equalTo(DEVICE_NAME)));
-        assertThat(enrollment.getGCMToken(), is(equalTo(DEVICE_GCM_TOKEN)));
-        assertThat(enrollment.getDeviceToken(), is(equalTo(DEVICE_TOKEN)));
-    }
-
-    @Test
-    public void shouldHaveCorrectDataAfterParcel() throws Exception {
-        ParcelableEnrollment originalEnrollment = new ParcelableEnrollment(URL_HTTP_WITH_FINAL_DASH, TENANT, USER, PERIOD,
-                DIGITS, ALGORITHM, SECRET_BASE32, DEVICE_ID, DEVICE_LOCAL_IDENTIFIER, DEVICE_NAME,
-                DEVICE_GCM_TOKEN, DEVICE_TOKEN);
-
-        Bundle bundle = new Bundle();
-        bundle.putParcelable("ENROLLMENT", originalEnrollment);
-        ParcelableEnrollment enrollment = bundle.getParcelable("ENROLLMENT");
-
-        assertThat(enrollment, is(notNullValue()));
-
         assertThat(enrollment.getUrl(), is(equalTo(URL_HTTP_WITH_FINAL_DASH)));
         assertThat(enrollment.getLabel(), is(equalTo(TENANT)));
         assertThat(enrollment.getUser(), is(equalTo(USER)));

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
@@ -89,7 +89,7 @@ public class GuardianTest {
         when(notification.getTransactionToken())
                 .thenReturn(TRANSACTION_TOKEN);
 
-        enrollment = new ParcelableEnrollment(
+        enrollment = new GuardianEnrollment(
                 GUARDIAN_URL, TENANT, USER, PERIOD, DIGITS, ALGORITHM, SECRET_BASE32, DEVICE_ID,
                 DEVICE_IDENTIFIER, DEVICE_NAME, GCM_TOKEN, DEVICE_TOKEN);
 
@@ -102,7 +102,7 @@ public class GuardianTest {
     @Test
     public void shouldReturnEnrollRequest() throws Exception {
         Uri enrollmentUri = createEnrollmentUri();
-        GuardianAPIRequest<ParcelableEnrollment> request = guardian
+        GuardianAPIRequest<Enrollment> request = guardian
                 .enroll(enrollmentUri, DEVICE_NAME, GCM_TOKEN);
 
         assertThat(request, is(instanceOf(EnrollRequest.class)));

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/ParcelableNotificationTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/ParcelableNotificationTest.java
@@ -115,7 +115,7 @@ public class ParcelableNotificationTest {
 
         ParcelableNotification notification = ParcelableNotification.parse(data);
 
-        ParcelableEnrollment enrollment = new ParcelableEnrollment(
+        Enrollment enrollment = new GuardianEnrollment(
                 HOSTNAME_HTTPS, null, null, 6, 30, null, null,
                 DEVICE_ID, null, null, null, null);
 


### PR DESCRIPTION
Replace with a package level access class GuardianEnrollment, the API only uses the Enrollment interface
The ParcelableEnrollment was kind of useless given the user could not extend it because there was no constructor and the impl was there to be used in guardian ui library, but we don't have it yet so why resctrict ourselves?
