### PR TITLE
Rename backend API fields

### DIFF
--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -206,10 +206,10 @@ public class GuardianAPIClient {
             claims.put("aud", getUrl());
             claims.put("iss", deviceIdentifier);
             claims.put("sub", challenge);
-            claims.put("auth0.guardian.method", "push");
-            claims.put("auth0.guardian.accepted", accepted);
+            claims.put("auth0_guardian_method", "push");
+            claims.put("auth0_guardian_accepted", accepted);
             if (reason != null) {
-                claims.put("auth0.guardian.reason", reason);
+                claims.put("auth0_guardian_reason", reason);
             }
             Gson gson = new GsonBuilder().create();
             String headerAndPayload = base64UrlSafeEncode(gson.toJson(headers).getBytes())

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -314,12 +314,12 @@ public class GuardianAPIClientTest {
         assertThat(payload, hasEntry("aud", (Object) apiClient.getUrl()));
         assertThat(payload, hasEntry("sub", (Object) CHALLENGE));
         assertThat(payload, hasEntry("iss", (Object) DEVICE_IDENTIFIER));
-        assertThat(payload, hasEntry("auth0.guardian.accepted", (Object) accepted));
-        assertThat(payload, hasEntry("auth0.guardian.method", (Object) "push"));
+        assertThat(payload, hasEntry("auth0_guardian_accepted", (Object) accepted));
+        assertThat(payload, hasEntry("auth0_guardian_method", (Object) "push"));
         if (!accepted && rejectReason != null) {
-            assertThat(payload, hasEntry("auth0.guardian.reason", (Object) rejectReason));
+            assertThat(payload, hasEntry("auth0_guardian_reason", (Object) rejectReason));
         } else {
-            assertThat(payload.containsKey("auth0.guardian.reason"), is(equalTo(false)));
+            assertThat(payload.containsKey("auth0_guardian_reason"), is(equalTo(false)));
         }
         assertThat(payload, hasKey("iat"));
         assertThat(payload, hasKey("exp"));


### PR DESCRIPTION
- We use snake_case for the body field to be consistent with other endpoints
- We changed the "namespace format" for our non-standard claims: we now use `auth0_guardian_` prefix, with `_` instead of `.`