### PR TITLE
Add "Auth0-Client" header

### DIFF
--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -299,7 +299,7 @@ public class GuardianAPIClient {
             final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
             final String clientInfo = Base64.encodeToString(
-                    String.format("{\"name\":\"GuardianSDK.Android\",\"version\":\"%s\"}",
+                    String.format("{\"name\":\"Guardian.Android\",\"version\":\"%s\"}",
                             BuildConfig.VERSION_NAME).getBytes(),
                     Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
 

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -226,7 +226,7 @@ public class GuardianAPIClientTest {
                 new InputStreamReader(
                         new ByteArrayInputStream(auth0ClientDecoded)), type);
         assertThat(auth0Client, is(notNullValue()));
-        assertThat(auth0Client, hasEntry("name", "GuardianSDK.Android"));
+        assertThat(auth0Client, hasEntry("name", "Guardian.Android"));
         assertThat(auth0Client, hasEntry("version", BuildConfig.VERSION_NAME));
     }
 


### PR DESCRIPTION
It's a Base64 (url safe) encoded json string like:

```json
{
  "name": "GuardianSDK.Android",
  "version": "0.1.0"
}
```