### PR TITLE
SDK user's app as "user-agent" header

### DIFF
--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -22,6 +22,7 @@
 
 package com.auth0.android.guardian.sdk;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -187,7 +188,17 @@ public class Guardian {
      */
     public static class Builder {
 
+        private final Context context;
         private Uri url;
+
+        /**
+         * Constructs an instance of a {@link Guardian} Builder
+         *
+         * @param context the android context
+         */
+        public Builder(Context context) {
+            this.context = context;
+        }
 
         /**
          * Set the URL of the Guardian server.
@@ -235,7 +246,7 @@ public class Guardian {
                 throw new IllegalStateException("You must set either a domain or an url");
             }
 
-            GuardianAPIClient client = new GuardianAPIClient.Builder()
+            GuardianAPIClient client = new GuardianAPIClient.Builder(context)
                     .url(url)
                     .build();
 

--- a/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/sdk/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -22,6 +22,7 @@
 
 package com.auth0.android.guardian.sdk;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -248,7 +249,17 @@ public class GuardianAPIClient {
      */
     public static class Builder {
 
+        private final Context context;
         private HttpUrl url;
+
+        /**
+         * Constructs an instance of a {@link GuardianAPIClient} Builder
+         *
+         * @param context the android context
+         */
+        public Builder(Context context) {
+            this.context = context;
+        }
 
         /**
          * Set the URL of the Guardian server.
@@ -298,6 +309,10 @@ public class GuardianAPIClient {
 
             final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
+            final String userAgent = String.format("%s Android %s",
+                    context.getPackageName(),
+                    Build.VERSION.RELEASE);
+
             final String clientInfo = Base64.encodeToString(
                     String.format("{\"name\":\"GuardianSDK.Android\",\"version\":\"%s\"}",
                             BuildConfig.VERSION_NAME).getBytes(),
@@ -308,13 +323,8 @@ public class GuardianAPIClient {
                 public Response intercept(Chain chain) throws IOException {
                     okhttp3.Request originalRequest = chain.request();
                     okhttp3.Request requestWithUserAgent = originalRequest.newBuilder()
-                            .header("Accept-Language",
-                                    Locale.getDefault().toString())
-                            .header("User-Agent",
-                                    String.format("GuardianSDK/%s(%s) Android %s",
-                                            BuildConfig.VERSION_NAME,
-                                            BuildConfig.VERSION_CODE,
-                                            Build.VERSION.RELEASE))
+                            .header("Accept-Language", Locale.getDefault().toString())
+                            .header("User-Agent", userAgent)
                             .header("Auth0-Client", clientInfo)
                             .build();
                     return chain.proceed(requestWithUserAgent);

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -42,6 +42,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
@@ -135,7 +136,7 @@ public class GuardianAPIClientTest {
         mockAPI = new MockWebService();
         final String domain = mockAPI.getDomain();
 
-        apiClient = new GuardianAPIClient.Builder()
+        apiClient = new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .url(Uri.parse(domain))
                 .build();
     }
@@ -147,7 +148,7 @@ public class GuardianAPIClientTest {
 
     @Test
     public void shouldBuildWithUrl() throws Exception {
-        GuardianAPIClient apiClient = new GuardianAPIClient.Builder()
+        GuardianAPIClient apiClient = new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .build();
 
@@ -157,7 +158,7 @@ public class GuardianAPIClientTest {
 
     @Test
     public void shouldBuildWithDomain() throws Exception {
-        GuardianAPIClient apiClient = new GuardianAPIClient.Builder()
+        GuardianAPIClient apiClient = new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .domain("example.guardian.auth0.com")
                 .build();
 
@@ -169,7 +170,7 @@ public class GuardianAPIClientTest {
     public void shouldFailIfDomainWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
 
-        new GuardianAPIClient.Builder()
+        new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .domain("example.guardian.auth0.com")
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .build();
@@ -179,7 +180,7 @@ public class GuardianAPIClientTest {
     public void shouldFailIfUrlWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
 
-        new GuardianAPIClient.Builder()
+        new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .domain("example.guardian.auth0.com")
                 .build();
@@ -189,7 +190,7 @@ public class GuardianAPIClientTest {
     public void shouldFailIfNoUrlOrDomainConfigured() throws Exception {
         exception.expect(IllegalStateException.class);
 
-        new GuardianAPIClient.Builder()
+        new GuardianAPIClient.Builder(RuntimeEnvironment.application)
                 .build();
     }
 
@@ -206,9 +207,8 @@ public class GuardianAPIClientTest {
         RecordedRequest request = mockAPI.takeRequest();
         assertThat(request.getHeader("User-Agent"),
                 is(equalTo(
-                        String.format("GuardianSDK/%s(%s) Android %s",
-                                BuildConfig.VERSION_NAME,
-                                BuildConfig.VERSION_CODE,
+                        String.format("%s Android %s",
+                                RuntimeEnvironment.application.getPackageName(),
                                 Build.VERSION.RELEASE))));
 
         assertThat(request.getHeader("Accept-Language"),

--- a/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
+++ b/guardian/sdk/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
@@ -31,6 +31,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.security.KeyPair;
@@ -221,7 +222,7 @@ public class GuardianTest {
 
     @Test
     public void shouldBuildWithUrl() throws Exception {
-        Guardian guardian = new Guardian.Builder()
+        Guardian guardian = new Guardian.Builder(RuntimeEnvironment.application)
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .build();
 
@@ -231,7 +232,7 @@ public class GuardianTest {
 
     @Test
     public void shouldBuildWithDomain() throws Exception {
-        Guardian guardian = new Guardian.Builder()
+        Guardian guardian = new Guardian.Builder(RuntimeEnvironment.application)
                 .domain("example.guardian.auth0.com")
                 .build();
 
@@ -243,7 +244,7 @@ public class GuardianTest {
     public void shouldFailIfDomainWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
 
-        new Guardian.Builder()
+        new Guardian.Builder(RuntimeEnvironment.application)
                 .domain("example.guardian.auth0.com")
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .build();
@@ -253,7 +254,7 @@ public class GuardianTest {
     public void shouldFailIfUrlWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
 
-        new Guardian.Builder()
+        new Guardian.Builder(RuntimeEnvironment.application)
                 .url(Uri.parse("https://example.guardian.auth0.com"))
                 .domain("example.guardian.auth0.com")
                 .build();
@@ -263,7 +264,7 @@ public class GuardianTest {
     public void shouldFailIfNoUrlOrDomainConfigured() throws Exception {
         exception.expect(IllegalStateException.class);
 
-        new Guardian.Builder()
+        new Guardian.Builder(RuntimeEnvironment.application)
                 .build();
     }
 


### PR DESCRIPTION
Right now we were sending the sdk info as user-agent. I added the Auth0-Client header instead, so this might be removed. But if we don't add ours, okhttp sends its own, which is useless...

So this tries to send info about the SDK user's app. **Major change: we'll need an context**. It looks like this:
```
User-Agent: <app_package_name> Android <Android_version>
```

