### PR TITLE
Add "enableLogging" method to enable logging of requests

### DIFF
--- a/app/src/main/java/com/auth0/guardian/sample/EnrollActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/EnrollActivity.java
@@ -166,6 +166,7 @@ public class EnrollActivity extends AppCompatActivity implements CaptureView.Lis
 
         guardian = new Guardian.Builder()
                 .url(Uri.parse(getString(R.string.guardian_url)))
+                .enableLogging()
                 .build();
     }
 

--- a/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
@@ -88,6 +88,7 @@ public class MainActivity extends AppCompatActivity implements GcmUtils.GcmToken
 
         guardian = new Guardian.Builder()
                 .url(Uri.parse(getString(R.string.guardian_url)))
+                .enableLogging()
                 .build();
 
         GcmUtils gcmUtils = new GcmUtils(this, getString(R.string.google_app_id));

--- a/app/src/main/java/com/auth0/guardian/sample/NotificationActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/NotificationActivity.java
@@ -70,6 +70,7 @@ public class NotificationActivity extends AppCompatActivity {
 
         guardian = new Guardian.Builder()
                 .url(Uri.parse(getString(R.string.guardian_url)))
+                .enableLogging()
                 .build();
 
         Intent intent = getIntent();

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -188,6 +188,7 @@ public class Guardian {
     public static class Builder {
 
         private Uri url;
+        private boolean loggingEnabled = false;
 
         /**
          * Set the URL of the Guardian server.
@@ -225,6 +226,16 @@ public class Guardian {
         }
 
         /**
+         * Enables the logging of all HTTP requests to the console.
+         *
+         * @return itself
+         */
+        public Builder enableLogging() {
+            this.loggingEnabled = true;
+            return this;
+        }
+
+        /**
          * Builds and returns the Guardian instance
          *
          * @return the created instance
@@ -235,11 +246,14 @@ public class Guardian {
                 throw new IllegalStateException("You must set either a domain or an url");
             }
 
-            GuardianAPIClient client = new GuardianAPIClient.Builder()
-                    .url(url)
-                    .build();
+            GuardianAPIClient.Builder builder = new GuardianAPIClient.Builder()
+                    .url(url);
 
-            return new Guardian(client);
+            if (loggingEnabled) {
+                builder.enableLogging();
+            }
+
+            return new Guardian(builder.build());
         }
     }
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -49,7 +49,7 @@ public class Guardian {
     /**
      * Creates an enroll. When successful, returns a new Enrollment that is required to allow or
      * reject authentication requests.
-     *
+     * <p>
      * This device will now be available as a Guardian second factor.
      *
      * @param enrollmentData the enrollment URI or ticket obtained from a Guardian QR code or
@@ -227,6 +227,8 @@ public class Guardian {
 
         /**
          * Enables the logging of all HTTP requests to the console.
+         * <p>
+         * Should only be used during development, on debug builds
          *
          * @return itself
          */

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -52,6 +52,7 @@ import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
+import okhttp3.logging.HttpLoggingInterceptor;
 
 /**
  * Low level API client for Guardian MFA server
@@ -247,6 +248,7 @@ public class GuardianAPIClient {
     public static class Builder {
 
         private HttpUrl url;
+        private boolean loggingEnabled = false;
 
         /**
          * Set the URL of the Guardian server.
@@ -256,7 +258,7 @@ public class GuardianAPIClient {
          * @return itself
          * @throws IllegalArgumentException when an url or domain was already set
          */
-        public GuardianAPIClient.Builder url(@NonNull Uri url) {
+        public Builder url(@NonNull Uri url) {
             if (this.url != null) {
                 throw new IllegalArgumentException("An url/domain was already set");
             }
@@ -272,7 +274,7 @@ public class GuardianAPIClient {
          * @return itself
          * @throws IllegalArgumentException when an url or domain was already set
          */
-        public GuardianAPIClient.Builder domain(@NonNull String domain) {
+        public Builder domain(@NonNull String domain) {
             if (this.url != null) {
                 throw new IllegalArgumentException("An url/domain was already set");
             }
@@ -280,6 +282,16 @@ public class GuardianAPIClient {
                     .scheme("https")
                     .host(domain)
                     .build();
+            return this;
+        }
+
+        /**
+         * Enables the logging of all HTTP requests to the console.
+         *
+         * @return itself
+         */
+        public Builder enableLogging() {
+            this.loggingEnabled = true;
             return this;
         }
 
@@ -318,6 +330,12 @@ public class GuardianAPIClient {
                     return chain.proceed(requestWithUserAgent);
                 }
             });
+
+            if (loggingEnabled) {
+                final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor()
+                        .setLevel(HttpLoggingInterceptor.Level.BODY);
+                builder.addInterceptor(loggingInterceptor);
+            }
 
             OkHttpClient client = builder.build();
 

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -56,7 +56,7 @@ import okhttp3.logging.HttpLoggingInterceptor;
 
 /**
  * Low level API client for Guardian MFA server
- *
+ * <p>
  * Use this API client to manually create enrollments, allow/reject authentication requests, and
  * manage an enrollment's device data
  */
@@ -85,9 +85,9 @@ public class GuardianAPIClient {
      * @param enrollmentTicket the enrollment ticket obtained from a Guardian QR code or enrollment
      *                         email
      * @param deviceIdentifier the local identifier that uniquely identifies the android device
-     * @param deviceName this device's name
-     * @param gcmToken the GCM token required to send push notifications to this device
-     * @param publicKey the RSA public key to associate with the enrollment
+     * @param deviceName       this device's name
+     * @param gcmToken         the GCM token required to send push notifications to this device
+     * @param publicKey        the RSA public key to associate with the enrollment
      * @return a request to execute or start
      */
     @NonNull
@@ -138,10 +138,10 @@ public class GuardianAPIClient {
     /**
      * Allows an authentication request using the enrollment's private key
      *
-     * @param txToken the auth transaction token
+     * @param txToken          the auth transaction token
      * @param deviceIdentifier the local device identifier
-     * @param challenge the one time password
-     * @param privateKey the private key used to sign the payload
+     * @param challenge        the one time password
+     * @param privateKey       the private key used to sign the payload
      * @return a request to execute
      * @throws GuardianException when signing with private key fails
      */
@@ -159,11 +159,11 @@ public class GuardianAPIClient {
     /**
      * Rejects an authentication request using the enrollment's private key, indicating a reason
      *
-     * @param txToken the auth transaction token
+     * @param txToken          the auth transaction token
      * @param deviceIdentifier the local device identifier
-     * @param challenge the one time password
-     * @param privateKey the private key used to sign the payload
-     * @param reason the reject reason
+     * @param challenge        the one time password
+     * @param privateKey       the private key used to sign the payload
+     * @param reason           the reject reason
      * @return a request to execute
      * @throws GuardianException when signing with private key fails
      */
@@ -182,10 +182,10 @@ public class GuardianAPIClient {
     /**
      * Rejects an authentication request using the enrollment's private key
      *
-     * @param txToken the auth transaction token
+     * @param txToken          the auth transaction token
      * @param deviceIdentifier the local device identifier
-     * @param challenge the one time password
-     * @param privateKey the private key used to sign the payload
+     * @param challenge        the one time password
+     * @param privateKey       the private key used to sign the payload
      * @return a request to execute
      * @throws GuardianException when signing with private key fails
      */
@@ -287,6 +287,8 @@ public class GuardianAPIClient {
 
         /**
          * Enables the logging of all HTTP requests to the console.
+         * <p>
+         * Should only be used during development, on debug builds
          *
          * @return itself
          */


### PR DESCRIPTION
Add "enableLogging" method to Builders to enable the logging of all HTTP requests

Closes #64 