### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ GuardianSDK is available both in [Maven Central](http://search.maven.org) and
 To start using *GuardianSDK* add these lines to your `build.gradle` dependencies file:
 
 ```gradle
-compile 'com.auth0.android:guardian:0.3.0'
+implementation 'com.auth0.android:guardian:0.3.0'
 ```
 
 ## Usage


### PR DESCRIPTION
The **compile** configuration is now deprecated and should be replaced by implementation or api.
From [Gradle Documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)