### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,20 +20,20 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
 
-    compile project(':guardian')
+    implementation project(':guardian')
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:design:25.3.1'
 
     //GCM
-    compile 'com.google.android.gms:play-services-gcm:10.2.1'
+    implementation 'com.google.android.gms:play-services-gcm:10.2.1'
 
     //EventBus
-    compile 'org.greenrobot:eventbus:3.0.0'
+    implementation 'org.greenrobot:eventbus:3.0.0'
 
     //ZXing QR decoder deps
-    compile 'com.google.zxing:core:3.2.1'
+    implementation 'com.google.zxing:core:3.2.1'
 }


### PR DESCRIPTION
Replaced

`compile `with `implementation`
`testCompile `with `testImplementation`

The **compile** configuration is now deprecated and should be replaced by implementation or api.
From [Gradle Documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)