### PR TITLE
Deprecate methods to parse a notification payload from a Bundle

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -147,11 +147,12 @@ public class Guardian {
      * @param pushNotificationPayload the GCM payload Bundle
      * @return the parsed data, or null if the push notification is not a valid Guardian
      * notification
+     * @deprecated After migrating to FCM you should use {@link #parseNotification(Map)} instead.
      */
     @SuppressWarnings("unused")
     @Nullable
+    @Deprecated
     public static ParcelableNotification parseNotification(@NonNull Bundle pushNotificationPayload) {
-        //FIXME: Deprecate
         return ParcelableNotification.parse(pushNotificationPayload);
     }
 

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/ParcelableNotification.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/ParcelableNotification.java
@@ -107,10 +107,11 @@ public class ParcelableNotification implements Notification, Parcelable {
      * @param pushNotificationPayload the GCM payload Bundle
      * @return the parsed data, or null if the push notification is not a valid Guardian
      * notification
+     * @deprecated After migrating to FCM you should use {@link #parse(Map)} instead.
      */
     @Nullable
+    @Deprecated
     public static ParcelableNotification parse(@NonNull Bundle pushNotificationPayload) {
-        //FIXME: Deprecate
         String hostname = pushNotificationPayload.getString(HOSTNAME_KEY);
         String enrollmentId = pushNotificationPayload.getString(ENROLLMENT_ID_KEY);
         String transactionToken = pushNotificationPayload.getString(TRANSACTION_TOKEN_KEY);


### PR DESCRIPTION
Deprecate static methods related to old GCM usage:

- `ParcelableNotification#parse(Bundle)`
- `Guardian#parseNotification(Bundle)`