### PR TITLE
[MFA-352] Fix url path to append enrollment path for psaas customers

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -154,7 +154,10 @@ public class GuardianAPIClient {
                                           @NonNull String deviceIdentifier,
                                           @NonNull String challenge,
                                           @NonNull PrivateKey privateKey) {
-        final HttpUrl url = baseUrl.resolve("api/resolve-transaction");
+        final HttpUrl url = baseUrl.newBuilder()
+                .addPathSegments("api/resolve-transaction")
+                .build();
+
         final String jwt = createJWT(privateKey, url.toString(), deviceIdentifier, challenge, true, null);
         return requestFactory
                 .<Void>newRequest("POST", url, Void.class)
@@ -178,7 +181,10 @@ public class GuardianAPIClient {
                                            @NonNull String challenge,
                                            @NonNull PrivateKey privateKey,
                                            @Nullable String reason) {
-        final HttpUrl url = baseUrl.resolve("api/resolve-transaction");
+        final HttpUrl url = baseUrl.newBuilder()
+                .addPathSegments("api/resolve-transaction")
+                .build();
+
         final String jwt = createJWT(privateKey, url.toString(), deviceIdentifier, challenge, false, reason);
         return requestFactory
                 .<Void>newRequest("POST", url, Void.class)

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -97,8 +97,13 @@ public class GuardianAPIClient {
                                                           @NonNull PublicKey publicKey) {
         Type type = new TypeToken<Map<String, Object>>() {
         }.getType();
+
+        HttpUrl url = baseUrl.newBuilder()
+                .addPathSegments("api/enroll")
+                .build();
+
         return requestFactory
-                .<Map<String, Object>>newRequest("POST", baseUrl.resolve("api/enroll"), type)
+                .<Map<String, Object>>newRequest("POST", url, type)
                 .setHeader("Authorization", String.format("Ticket id=\"%s\"", enrollmentTicket))
                 .setParameter("identifier", deviceIdentifier)
                 .setParameter("name", deviceName)

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -307,6 +307,27 @@ public class GuardianAPIClientTest {
     }
 
     @Test
+    public void shouldCallTheRightUrlWhenUsingPathSegmentsWithTrailingSlash() throws Exception {
+        MockWebService newMockWebService = new MockWebService();
+        final String domain = newMockWebService.getDomain();
+        GuardianAPIClient apiClientPSaaS = new GuardianAPIClient.Builder()
+                .url(Uri.parse(domain + "appliance-mfa/"))
+                .build();
+
+        newMockWebService.willReturnEnrollment(ENROLLMENT_ID, PSAAS_ENROLLMENT_URL, ENROLLMENT_ISSUER, ENROLLMENT_USER,
+                DEVICE_ACCOUNT_TOKEN, RECOVERY_CODE, TOTP_SECRET, TOTP_ALGORITHM, TOTP_DIGITS, TOTP_PERIOD);
+
+        apiClientPSaaS.enroll(ENROLLMENT_TICKET, DEVICE_IDENTIFIER, DEVICE_NAME, GCM_TOKEN, publicKey)
+                .start(enrollCallback);
+
+        RecordedRequest request = newMockWebService.takeRequest();
+
+        assertThat(request.getPath(), is(equalTo("/appliance-mfa/api/enroll")));
+        assertThat(request.getMethod(), is(equalTo("POST")));
+        assertThat(request.getHeader("Authorization"), is(equalTo("Ticket id=\"" + ENROLLMENT_TICKET + "\"")));
+    }
+
+    @Test
     public void shouldFailEnrollIfNotRSA() throws Exception {
         exception.expect(IllegalArgumentException.class);
 


### PR DESCRIPTION
### Description
Guardian Android App does not work in PSaaS environment. 

In the PSaaS environment, the MFA login url end is `https://{{baseURL}}.com/appliance-mfa`. 
When redirecting to mfa-api, the path `/api-enroll` should be appended to the above url. This was not happening.
Instead, `/api-enroll` was _replacing_  `/appliance-mfa`
This PR changes the way we append paths from using `.resolve` to `.addPathSegments`


### References
https://auth0team.atlassian.net/browse/MFA-352


### Testing
This can be tested by running the GuardianApp.Android application and importing this branch  instead of:
`implementation "com.auth0.android:guardian:0.3.0"` in the build.gradle

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
