### PR TITLE
Update dependencies and plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 jobs:
   build:
-    environment:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
-      _JAVA_OPTIONS: -Xms512m -Xmx1024m
     docker:
       - image: circleci/android:api-28
 
@@ -13,14 +10,13 @@ jobs:
         keys:
         - dep-{{ checksum "./guardian/build.gradle" }}-{{ checksum "./app/build.gradle" }}
         - dep-
-    - run: ./gradlew clean build
+    - run: ./gradlew clean test jacocoTestReport --continue --console=plain --max-workers 4
     - save_cache:
         key: dep-{{ checksum "./guardian/build.gradle" }}-{{ checksum "./app/build.gradle" }}
         paths:
-        - ~/.gradle
-        - ~/.android
-        - /usr/local/android-sdk-linux/extras
-    - run: ./gradlew clean test jacocoTestReport --continue --console=plain
+          - ~/.gradle
+          - ~/.android
+          - /usr/local/android-sdk-linux/extras
     - run:
           name: Upload Coverage
           when: on_success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,16 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - dep-{{ checksum "./app/build.gradle" }}
+        - dep-{{ checksum "./guardian/build.gradle" }}-{{ checksum "./app/build.gradle" }}
         - dep-
     - run: ./gradlew clean build
     - save_cache:
-        key: dep-{{ checksum "./app/build.gradle" }}
+        key: dep-{{ checksum "./guardian/build.gradle" }}-{{ checksum "./app/build.gradle" }}
         paths:
         - ~/.gradle
         - ~/.android
         - /usr/local/android-sdk-linux/extras
-    - run: ./gradlew test jacocoTestReport --continue --console=plain
+    - run: ./gradlew clean test jacocoTestReport --continue --console=plain
     - run:
           name: Upload Coverage
           when: on_success

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.android.support:design:28.0.0'
     //GSON
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
     //FCM
     implementation 'com.google.firebase:firebase-core:16.0.8'
     implementation 'com.google.firebase:firebase-messaging:17.5.0'
@@ -37,5 +37,5 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.0.0'
     //ZXing QR decoder deps
     implementation 'com.google.zxing:core:3.2.1'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests {
+            all {
+                maxHeapSize = "1024m"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/app/src/main/res/layout/activity_enroll.xml
+++ b/app/src/main/res/layout/activity_enroll.xml
@@ -50,6 +50,7 @@
                 android:paddingTop="@dimen/activity_vertical_margin"
                 android:text="Scan a Guardian QR code"
                 android:textAlignment="center"
+                android:gravity="center_horizontal"
                 android:textSize="16sp" />
 
         </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 
@@ -19,8 +19,4 @@ allprojects {
         google()
         jcenter()
     }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Jul 30 17:41:05 ART 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -41,6 +41,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests {
+            all {
+                maxHeapSize = "1024m"
+            }
+        }
+    }
 }
 
 dependencies {

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.8.0"
+    id "com.auth0.gradle.oss-library.android" version "0.12.1"
 }
 
 logger.lifecycle("Using version ${version} for ${name}")
@@ -48,21 +48,21 @@ dependencies {
     // Annotations (@NonNull etc)
     implementation 'com.android.support:support-annotations:28.0.0'
     //Gson
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
     //OkHttp
-    implementation 'com.squareup.okhttp3:okhttp:3.14.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.9'
     //Mockito
-    testImplementation 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     //Hamcrest matchers
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     //OkHttp MockWebServer
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.14.9'
     //Awaitility
     testImplementation 'com.jayway.awaitility:awaitility:1.7.0'
     //Robolectric
-    testImplementation 'org.robolectric:robolectric:3.1.2'
+    testImplementation 'org.robolectric:robolectric:3.8'
     // JWT verification
     testImplementation 'com.auth0:java-jwt:2.3.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
 }


### PR DESCRIPTION
### Description

- Bumps the OSS release plugin to the latest version (0.12.1)
- Bumps most of the dependencies that don't include breaking changes
- Bumps the android gradle plugin to the latest version
- Updates the gradle wrapper

### References
I had to fix the CI script as the build was running out of memory
- https://circleci.com/docs/2.0/language-android/#handling-out-of-memory-errors

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
