### PR TITLE
Add support for transaction linking id [SDK-3879]

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Notification.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Notification.java
@@ -121,6 +121,15 @@ public interface Notification {
     Double getLongitude();
 
     /**
+     * The transaction linking id, used to correlate the notification with
+     * an ongoing authorization transaction
+     *
+     * @return the transaction linking id
+     */
+    @Nullable
+    String getTransactionLinkingId();
+
+    /**
      * The challenge sent by the server. The same challenge should be sent back when trying to
      * allow or reject an authentication request
      *

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/ParcelableNotification.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/ParcelableNotification.java
@@ -49,6 +49,7 @@ public class ParcelableNotification implements Notification, Parcelable {
     private static final String TAG = ParcelableNotification.class.getName();
 
     private static final String TRANSACTION_TOKEN_KEY = "txtkn";
+    private static final String TRANSACTION_LINKING_ID_KEY = "txlnkid";
     private static final String ENROLLMENT_ID_KEY = "dai";
     private static final String DATE_KEY = "d";
     private static final String SOURCE_KEY = "s";
@@ -73,6 +74,7 @@ public class ParcelableNotification implements Notification, Parcelable {
     private final String location;
     private final Double latitude;
     private final Double longitude;
+    private final String transactionLinkingId;
     private final String challenge;
 
     ParcelableNotification(@NonNull HttpUrl url,
@@ -86,6 +88,7 @@ public class ParcelableNotification implements Notification, Parcelable {
                            @Nullable String location,
                            @Nullable Double latitude,
                            @Nullable Double longitude,
+                           @Nullable String transactionLinkingId,
                            @NonNull String challenge) {
         this.url = url.toString();
         this.enrollmentId = deviceId;
@@ -98,6 +101,7 @@ public class ParcelableNotification implements Notification, Parcelable {
         this.location = location;
         this.latitude = latitude;
         this.longitude = longitude;
+        this.transactionLinkingId = transactionLinkingId;
         this.challenge = challenge;
     }
 
@@ -115,6 +119,7 @@ public class ParcelableNotification implements Notification, Parcelable {
         String hostname = pushNotificationPayload.getString(HOSTNAME_KEY);
         String enrollmentId = pushNotificationPayload.getString(ENROLLMENT_ID_KEY);
         String transactionToken = pushNotificationPayload.getString(TRANSACTION_TOKEN_KEY);
+        String transactionLinkingId = pushNotificationPayload.getString(TRANSACTION_LINKING_ID_KEY);
         String challenge = pushNotificationPayload.getString(CHALLENGE_KEY);
         Date date = parseDate(pushNotificationPayload);
 
@@ -128,7 +133,7 @@ public class ParcelableNotification implements Notification, Parcelable {
 
         return new ParcelableNotification(url, enrollmentId, transactionToken, date,
                 source.osName, source.osVersion, source.browserName, source.browserVersion,
-                location.location, location.latitude, location.longitude, challenge);
+                location.location, location.latitude, location.longitude, transactionLinkingId, challenge);
     }
 
     /**
@@ -211,6 +216,12 @@ public class ParcelableNotification implements Notification, Parcelable {
     @Override
     public Double getLongitude() {
         return longitude;
+    }
+
+    @Nullable
+    @Override
+    public String getTransactionLinkingId() {
+        return transactionLinkingId;
     }
 
     @NonNull
@@ -356,6 +367,7 @@ public class ParcelableNotification implements Notification, Parcelable {
         location = in.readString();
         latitude = in.readByte() == 0x00 ? null : in.readDouble();
         longitude = in.readByte() == 0x00 ? null : in.readDouble();
+        transactionLinkingId = in.readString();
         challenge = in.readString();
     }
 
@@ -387,6 +399,7 @@ public class ParcelableNotification implements Notification, Parcelable {
             dest.writeByte((byte) (0x01));
             dest.writeDouble(longitude);
         }
+        dest.writeString(transactionLinkingId);
         dest.writeString(challenge);
     }
 

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/ParcelableNotificationTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/ParcelableNotificationTest.java
@@ -66,6 +66,7 @@ public class ParcelableNotificationTest {
     private static final String OS_NAME = "OS_NAME";
     private static final String OS_VERSION = "OS_VERSION";
     private static final String LOCATION = "LOCATION";
+    private static final String TRANSACTION_LINKING_ID = "TRANSACTION_LINKING_ID";
     private static final Double LATITUDE = 56.87;
     private static final Double LONGITUDE = 34.34;
 
@@ -100,6 +101,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
 
         Bundle bundleData = BundleUtils.mapToBundle(mapData);
@@ -117,6 +119,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
     }
 
@@ -140,6 +143,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
 
         Bundle bundleData = BundleUtils.mapToBundle(mapData);
@@ -157,6 +161,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
     }
 
@@ -180,6 +185,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
 
         Bundle bundleData = BundleUtils.mapToBundle(mapData);
@@ -197,6 +203,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
     }
 
@@ -226,6 +233,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
 
 
@@ -249,6 +257,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
         assertThat(notification.getLongitude(), is(equalTo(LONGITUDE)));
+        assertThat(notification.getTransactionLinkingId(), is(equalTo(TRANSACTION_LINKING_ID)));
         assertThat(notification.getChallenge(), is(equalTo(CHALLENGE)));
     }
 
@@ -256,7 +265,7 @@ public class ParcelableNotificationTest {
     public void shouldHaveCorrectDataAfterParcelWithNulls() {
         ParcelableNotification originalNotification = new ParcelableNotification(
                 HttpUrl.parse(HOSTNAME_HTTPS), DEVICE_ID, TRANSACTION_TOKEN, null,
-                OS_NAME, OS_VERSION, BROWSER_NAME, BROWSER_VERSION, LOCATION, null, null, CHALLENGE);
+                OS_NAME, OS_VERSION, BROWSER_NAME, BROWSER_VERSION, LOCATION, null, null, null, CHALLENGE);
 
         Parcel parcel = Parcel.obtain();
         originalNotification.writeToParcel(parcel, 0);
@@ -276,6 +285,7 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(nullValue()));
         assertThat(notification.getLongitude(), is(nullValue()));
+        assertThat(notification.getTransactionLinkingId(), is(nullValue()));
         assertThat(notification.getChallenge(), is(CHALLENGE));
     }
 
@@ -283,7 +293,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullSource() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                null, null, null, null, LOCATION, LATITUDE, LONGITUDE);
+                null, null, null, null, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -306,7 +316,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullBrowser() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                null, null, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE);
+                null, null, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -329,7 +339,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullBrowserName() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                null, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE);
+                null, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -352,7 +362,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullBrowserVersion() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, null, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE);
+                BROWSER_NAME, null, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -376,7 +386,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullOs() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, null, null, LOCATION, LATITUDE, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, null, null, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -400,7 +410,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullOsName() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, null, OS_VERSION, LOCATION, LATITUDE, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, null, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -424,7 +434,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullOsVersion() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, null, LOCATION, LATITUDE, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, null, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -448,7 +458,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullLocation() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, null, null, null);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, null, null, null, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -470,7 +480,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullLocationName() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, null, LATITUDE, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, null, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -491,7 +501,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullLatitude() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, null, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, null, LONGITUDE, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -513,7 +523,7 @@ public class ParcelableNotificationTest {
     public void shouldReturnNullLongitude() {
         Map<String, String> mapData = createPushNotificationPayload(
                 HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, null);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, null, TRANSACTION_LINKING_ID);
         ParcelableNotification notification = ParcelableNotification.parse(mapData);
 
         assertThat(notification, is(notNullValue()));
@@ -529,6 +539,23 @@ public class ParcelableNotificationTest {
         assertThat(notification.getLongitude(), is(nullValue()));
         assertThat(notification.getLocation(), is(equalTo(LOCATION)));
         assertThat(notification.getLatitude(), is(equalTo(LATITUDE)));
+    }
+
+    @Test
+    public void shouldReturnNullTransactionLinkingId() {
+        Map<String, String> mapData = createPushNotificationPayload(
+                HOSTNAME, DEVICE_ID, TRANSACTION_TOKEN, new Date(), CHALLENGE,
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, null);
+        ParcelableNotification notification = ParcelableNotification.parse(mapData);
+
+        assertThat(notification, is(notNullValue()));
+        assertThat(notification.getTransactionLinkingId(), is(nullValue()));
+
+        Bundle bundleData = BundleUtils.mapToBundle(mapData);
+        notification = ParcelableNotification.parse(bundleData);
+
+        assertThat(notification, is(notNullValue()));
+        assertThat(notification.getTransactionLinkingId(), is(nullValue()));
     }
 
     @Test
@@ -610,7 +637,7 @@ public class ParcelableNotificationTest {
                                                               Date date,
                                                               String challenge) {
         return createPushNotificationPayload(hostname, deviceId, transactionToken, date, challenge,
-                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE);
+                BROWSER_NAME, BROWSER_VERSION, OS_NAME, OS_VERSION, LOCATION, LATITUDE, LONGITUDE, TRANSACTION_LINKING_ID);
     }
 
     private Map<String, String> createPushNotificationPayload(String hostname,
@@ -624,7 +651,8 @@ public class ParcelableNotificationTest {
                                                               String osVersion,
                                                               String location,
                                                               Double latitude,
-                                                              Double longitude) {
+                                                              Double longitude,
+                                                              String transactionLinkingId) {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
@@ -663,6 +691,7 @@ public class ParcelableNotificationTest {
         data.put("sh", hostname);
         data.put("txtkn", transactionToken);
         data.put("dai", deviceId);
+        data.put("txlnkid", transactionLinkingId);
         data.put("c", challenge);
 
         return data;


### PR DESCRIPTION
### Description
To support contextual push notifications, the notification payload will include a new `txlnkid` string property, which stands for “transaction linking id“.

This PR adds support for this new property, by exposing it in the `Notification` public API through a new `getTransactionLinkingId` getter function. This method is annotated with `@Nullable` because `txlnkid` will not always be present in the notification payload.
 
### Testing
Unit tests were added.

* [x]  This change adds test coverage for new/changed/fixed functionality
 
### Checklist
* [x]  I have added documentation for new/changed functionality in this PR or in auth0.com/docs
* [ ]  All active GitHub checks for tests, formatting, and security are passing
* [x]  The correct base branch is being used, if not the default branch

