### PR TITLE
fix: explicitly use `this.url` instead of only `url`

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -358,7 +358,7 @@ public class GuardianAPIClient {
          * @throws IllegalStateException when the builder was not configured correctly
          */
         public GuardianAPIClient build() {
-            if (url == null) {
+            if (this.url == null) {
                 throw new IllegalStateException("You must set either a domain or an url");
             }
 
@@ -398,7 +398,7 @@ public class GuardianAPIClient {
 
             RequestFactory requestFactory = new RequestFactory(gson, client);
 
-            return new GuardianAPIClient(requestFactory, url);
+            return new GuardianAPIClient(requestFactory, this.url);
         }
     }
 }


### PR DESCRIPTION
### Description

This resolves an issue we are facing with using the android SDK for GUardian auth

### Testing
No functional changes

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
