### PR TITLE
[MFA-2681] Add advanced telemetry to SDK

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/ClientInfo.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/ClientInfo.java
@@ -1,0 +1,46 @@
+package com.auth0.android.guardian.sdk;
+
+import android.util.Base64;
+
+import androidx.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public class ClientInfo {
+    final String name = "Guardian.Android";
+    final String version = BuildConfig.VERSION_NAME;
+
+    @SerializedName("env")
+    @Nullable
+    TelemetryInfo telemetryInfo;
+
+    public ClientInfo (TelemetryInfo telemetryInfo) {
+        this.telemetryInfo = telemetryInfo;
+    }
+
+    public ClientInfo () {
+        this.telemetryInfo = null;
+    }
+
+    String toJson() {
+        Gson gson = new GsonBuilder().create();
+        return gson.toJson(this);
+    }
+
+    String toBase64() {
+        byte[] bytes = this.toJson().getBytes();
+        return Base64.encodeToString(bytes, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+    }
+
+    public static class TelemetryInfo {
+        String appName;
+        String appVersion;
+
+        public TelemetryInfo(String appName, String appVersion) {
+            this.appName = appName;
+            this.appVersion = appVersion;
+        }
+    }
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/DeviceAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/DeviceAPIClient.java
@@ -43,13 +43,20 @@ public class DeviceAPIClient {
     private final HttpUrl url;
     private final String token;
 
+    private final ClientInfo clientInfo;
+
     DeviceAPIClient(RequestFactory requestFactory, HttpUrl baseUrl, String id, String token) {
+        this(requestFactory, baseUrl, id, token, null);
+    }
+
+    DeviceAPIClient(RequestFactory requestFactory, HttpUrl baseUrl, String id, String token, @Nullable ClientInfo.TelemetryInfo telemetryInfo) {
         this.requestFactory = requestFactory;
         this.url = baseUrl.newBuilder()
                 .addPathSegments("api/device-accounts")
                 .addPathSegment(id)
                 .build();
         this.token = token;
+        this.clientInfo = new ClientInfo(telemetryInfo);
     }
 
     /**
@@ -60,6 +67,7 @@ public class DeviceAPIClient {
     public GuardianAPIRequest<Void> delete() {
         return requestFactory
                 .<Void>newRequest("DELETE", url, Void.class)
+                .setHeader("Auth0-Client", this.clientInfo.toBase64())
                 .setBearer(token);
     }
 
@@ -80,6 +88,7 @@ public class DeviceAPIClient {
                                                           @Nullable String gcmToken) {
         Type type = new TypeToken<Map<String, Object>>() {}.getType();
         return requestFactory.<Map<String, Object>>newRequest("PATCH", url, type)
+                .setHeader("Auth0-Client", this.clientInfo.toBase64())
                 .setBearer(token)
                 .setParameter("identifier", identifier)
                 .setParameter("name", name)

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -279,7 +279,7 @@ public class Guardian {
                 builder.enableLogging();
             }
 
-            if (this.telemetryInfo != null) {
+            if (telemetryInfo != null) {
                 builder.setTelemetryInfo(telemetryInfo.appName, telemetryInfo.appVersion);
             }
 

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -24,6 +24,7 @@ package com.auth0.android.guardian.sdk;
 
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -253,6 +254,13 @@ public class Guardian {
             return this;
         }
 
+        private ClientInfo.TelemetryInfo telemetryInfo;
+
+        public Builder setTelemetryInfo(String appName, String appVersion) {
+            this.telemetryInfo = new ClientInfo.TelemetryInfo(appName, appVersion);
+            return this;
+        }
+
         /**
          * Builds and returns the Guardian instance
          *
@@ -269,6 +277,10 @@ public class Guardian {
 
             if (loggingEnabled) {
                 builder.enableLogging();
+            }
+
+            if (this.telemetryInfo != null) {
+                builder.setTelemetryInfo(telemetryInfo.appName, telemetryInfo.appVersion);
             }
 
             return new Guardian(builder.build());

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -415,6 +415,10 @@ public class GuardianAPIClient {
 
             RequestFactory requestFactory = new RequestFactory(gson, client);
 
+            if(clientInfo.telemetryInfo != null) {
+                return new GuardianAPIClient(requestFactory, url, clientInfo.telemetryInfo);
+            }
+
             return new GuardianAPIClient(requestFactory, url);
         }
     }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -67,9 +67,19 @@ public class GuardianAPIClient {
     private final RequestFactory requestFactory;
     private final HttpUrl baseUrl;
 
+    private final ClientInfo clientInfo;
+
+
     GuardianAPIClient(RequestFactory requestFactory, HttpUrl baseUrl) {
         this.requestFactory = requestFactory;
         this.baseUrl = baseUrl;
+        this.clientInfo = new ClientInfo(null);
+    }
+
+    GuardianAPIClient(RequestFactory requestFactory, HttpUrl baseUrl, ClientInfo.TelemetryInfo telemetryInfo) {
+        this.requestFactory = requestFactory;
+        this.baseUrl = baseUrl;
+        this.clientInfo = new ClientInfo(telemetryInfo);
     }
 
     String getUrl() {
@@ -106,6 +116,7 @@ public class GuardianAPIClient {
         return requestFactory
                 .<Map<String, Object>>newRequest("POST", url, type)
                 .setHeader("Authorization", String.format("Ticket id=\"%s\"", enrollmentTicket))
+                .setHeader("Auth0-Client", this.clientInfo.toBase64())
                 .setParameter("identifier", deviceIdentifier)
                 .setParameter("name", deviceName)
                 .setParameter("push_credentials", createPushCredentials(gcmToken))
@@ -162,6 +173,7 @@ public class GuardianAPIClient {
         final String jwt = createAccessApprovalJWT(privateKey, url.toString(), deviceIdentifier, challenge, true, null);
         return requestFactory
                 .<Void>newRequest("POST", url, Void.class)
+                .setHeader("Auth0-Client", this.clientInfo.toBase64())
                 .setBearer(txToken)
                 .setParameter("challenge_response", jwt);
     }
@@ -189,6 +201,7 @@ public class GuardianAPIClient {
         final String jwt = createAccessApprovalJWT(privateKey, url.toString(), deviceIdentifier, challenge, false, reason);
         return requestFactory
                 .<Void>newRequest("POST", url, Void.class)
+                .setHeader("Auth0-Client", this.clientInfo.toBase64())
                 .setBearer(txToken)
                 .setParameter("challenge_response", jwt);
     }
@@ -351,6 +364,13 @@ public class GuardianAPIClient {
             return this;
         }
 
+        ClientInfo clientInfo = new ClientInfo();
+
+        public Builder setTelemetryInfo(String appName, String appVersion) {
+            this.clientInfo.telemetryInfo = new ClientInfo.TelemetryInfo(appName, appVersion);
+            return this;
+        }
+
         /**
          * Builds and returns the GuardianAPIClient instance
          *
@@ -364,10 +384,7 @@ public class GuardianAPIClient {
 
             final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
-            final String clientInfo = Base64.encodeToString(
-                    String.format("{\"name\":\"Guardian.Android\",\"version\":\"%s\"}",
-                            BuildConfig.VERSION_NAME).getBytes(),
-                    Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+            final String encodedClientInfo = this.clientInfo.toBase64();
 
             builder.addInterceptor(new Interceptor() {
                 @Override
@@ -380,7 +397,7 @@ public class GuardianAPIClient {
                                     String.format("GuardianSDK/%s Android %s",
                                             BuildConfig.VERSION_NAME,
                                             Build.VERSION.RELEASE))
-                            .header("Auth0-Client", clientInfo)
+                            .header("Auth0-Client", encodedClientInfo)
                             .build();
                     return chain.proceed(requestWithUserAgent);
                 }

--- a/guardian/src/test/java/android/util/Base64.java
+++ b/guardian/src/test/java/android/util/Base64.java
@@ -1,0 +1,25 @@
+package android.util;
+
+import android.os.Build;
+
+import java.nio.charset.StandardCharsets;
+
+public class Base64 {
+    public static final int NO_PADDING = 1;
+    public static final int NO_WRAP = 2;
+    public static final int URL_SAFE = 8;
+    public static String encodeToString(byte[] input, int flags) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return java.util.Base64.getEncoder().encodeToString(input);
+        }
+        return "eh?";
+    }
+
+    public static byte[] decode(String str, int flags) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return java.util.Base64.getDecoder().decode(str);
+        }
+
+        return "eh?".getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
@@ -245,6 +245,17 @@ public class GuardianTest {
     }
 
     @Test
+    public void shouldBuildWithTelemetryInfo() throws Exception {
+        Guardian guardian = new Guardian.Builder()
+                .domain("example.guardian.auth0.com")
+                .setTelemetryInfo("SomeAppName", "1.2.3")
+                .build();
+
+        assertThat(guardian.getAPIClient().getUrl(),
+                is(equalTo("https://example.guardian.auth0.com/")));
+    }
+
+    @Test
     public void shouldFailIfDomainWasAlreadySet() throws Exception {
         exception.expect(IllegalArgumentException.class);
 


### PR DESCRIPTION
### Description

SDK should allow for an additional telemetry info that will be sent in requests to mfa-api. If not provided, a default value is set.

### References
https://auth0team.atlassian.net/browse/MFA-2681


### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
