### PR TITLE
fix(okhttp-bom): use platform keyword to implement okhttp-bom

### DIFF
--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     // Gson
     implementation 'com.google.code.gson:gson:2.9.1'
     // OkHttp
-    implementation 'com.squareup.okhttp3:okhttp-bom:4.10.0'
+    implementation platform('com.squareup.okhttp3:okhttp-bom:4.10.0')
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     testImplementation 'com.squareup.okhttp3:mockwebserver'


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

There is an error when importing this package on newer android version. As said in this [issue](https://github.com/auth0/Guardian.Android/issues/117) the `okhttp-bom` wasn't imported correctly.

I used the keyword `platform` to import `okhttp-bom`.


### References

You will find my issue [here](https://github.com/auth0/Guardian.Android/issues/117).
I also think this [issue](https://github.com/auth0/Guardian.Android/issues/116) will be fixed by my fix.

### Testing

I tried it on my app, now it compile and work.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
