### PR TITLE
Fix for JsonIOException

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/networking/Request.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/networking/Request.java
@@ -175,6 +175,7 @@ public class Request<T> implements GuardianAPIRequest<T> {
     private T payloadFromResponse(Response response) throws GuardianException {
         try {
             final Reader reader = response.body().charStream();
+            if (typeOfT == Void.class) return null;
             return converter.parse(typeOfT, reader);
         } catch (Exception e) {
             throw new GuardianException("Error parsing server response", e);


### PR DESCRIPTION
There was an issue where method payloadFromResponse() threw a JsonIOException when the callback type was specified as void. This happened because the GsonConverter cannot directly handle Void type. To resolve this, I added line of code that checks the callback type and returns null if callback type is Void
