### PR TITLE
feat: rich consents

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ The `deviceName` and `fcmToken` are data that you must provide:
   is not yet using FCM or you're not familiar with it, you should check their
   [docs](https://firebase.google.com/docs/cloud-messaging/android/client#sample-register).
 
+#### A note about key generation
+
+The Guardian SDK does not provided methods for generating and storing cryptographic keys used for enrollment,
+as this is an application specific concern and could vary between targeted versions of Android and the 
+OEM-specific builds. The example given above and that used in the sample application is a naive implementation 
+which may not be suitable for production applications. It is recommended that you follow [OWASP guidelines
+for Android Cryptographic APIs](https://mas.owasp.org/MASTG/0x05e-Testing-Cryptography/) for your implementation.
+
+As of version 1.9.0 the public key used for enrollment was added to the Enrollment Interface as it is
+required for [fetching rich-consent details](#fetch-rich-consent-details). For new installs,
+this is not a a concern. For enrollments created prior to this version, depending on implementation, 
+this key may or may not have been stored with the enrollment information. If this key was discarded, 
+it may be possible to reconstruct from the stored signing key. The sample app provides 
+[an example](app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java#L194) of this. If 
+this is not possible, devices will require re-enrollment to make use of this functionality.
+
 ### Unenroll
 
 If you want to delete an enrollment -for example if you want to disable MFA- you can make the

--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ guardian
 
 ### Fetch rich consent details
 
-When you receive a push notification, the presence of the property `tranactionLinkingId` indicates a
-rich consent record may be associated to the tranaction.
+When you receive a push notification, the presence of the property `transactionLinkingId` indicates a
+rich consent record may be associated to the transaction.
 
 To fetch the rich consent details, you can use the `fetchConsent` method.
 
 ```java
-if (notification.getTranactionLinkingId() != null) {
+if (notification.getTransctionLinkingId() != null) {
     guardian
       .fetchConsent(notification, enrollment)
       .start(new Callback<Enrollment> {
@@ -200,7 +200,7 @@ if (notification.getTranactionLinkingId() != null) {
           if (exception instanceof GuardianException) {
             GuardianException guardianException = (GuardianException) exception;
             if (guardianException.isResourceNotFound()) {
-              // there is no consent associated with the tranaction
+              // there is no consent associated with the transaction
             }
           }
           // something went wrong 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Guardian SDK for Android
-============
+# Guardian SDK for Android
+
 [![CircleCI](https://img.shields.io/circleci/project/github/auth0/Guardian.Android.svg)](https://circleci.com/gh/auth0/Guardian.Android)
 [![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Guardian.Android/master.svg)](https://codecov.io/github/auth0/Guardian.Android)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
@@ -30,7 +30,7 @@ credentials, otherwise you would not receive any push notifications. Please read
 
 GuardianSDK is available both in [Maven Central](http://search.maven.org) and
 [JCenter](https://bintray.com/bintray/jcenter).
-To start using *GuardianSDK* add these lines to your `build.gradle` dependencies file:
+To start using _GuardianSDK_ add these lines to your `build.gradle` dependencies file:
 
 ```gradle
 implementation 'com.auth0.android:guardian:0.8.0'
@@ -113,11 +113,11 @@ guardian
 The `deviceName` and `fcmToken` are data that you must provide:
 
 - The `deviceName` is the name that you want for the enrollment. It will be displayed to the user
-when the second factor is required.
+  when the second factor is required.
 
 - The FCM token is the token for Firebase Cloud Messaging push notification service. In case your app
-is not yet using FCM or you're not familiar with it, you should check their
-[docs](https://firebase.google.com/docs/cloud-messaging/android/client#sample-register).
+  is not yet using FCM or you're not familiar with it, you should check their
+  [docs](https://firebase.google.com/docs/cloud-messaging/android/client#sample-register).
 
 ### Unenroll
 
@@ -136,8 +136,8 @@ Once you have the enrollment in place, you will receive a FCM push notification 
 has to validate his identity with MFA.
 
 Guardian provides a method to parse the `Map<String, String>` data inside the
- [RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage)
- received from FCM and return a `Notification` instance ready to be used.
+[RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage)
+received from FCM and return a `Notification` instance ready to be used.
 
 ```java
 // at your FCM listener you receive a RemoteMessage
@@ -154,12 +154,12 @@ public void onMessageReceived(RemoteMessage message) {
 ```
 
 > If the `RemoteMessage` you receive is not from a Guardian notification this method will return null,
- so you should always check before using it.
+> so you should always check before using it.
 
 Once you have the notification instance, you can easily allow the authentication request by using the
- `allow` method. You'll also need the enrollment that you obtained previously. In case you have more
-  than one enrollment, you'll have to find the one that has the same id as the notification (you can
-  get the enrollment id with `getEnrollmentId()`.
+`allow` method. You'll also need the enrollment that you obtained previously. In case you have more
+than one enrollment, you'll have to find the one that has the same id as the notification (you can
+get the enrollment id with `getEnrollmentId()`.
 
 ```java
 guardian
@@ -178,23 +178,54 @@ guardian
   .execute(); // or start(new Callback<> ...) asynchronously
 ```
 
+### Fetch rich consent details
+
+When you receive a push notification, the presence of the property `tranactionLinkingId` indicates a
+rich consent record may be associated to the tranaction.
+
+To fetch the rich consent details, you can use the `fetchConsent` method.
+
+```java
+if (notification.getTranactionLinkingId() != null) {
+    guardian
+      .fetchConsent(notification, enrollment)
+      .start(new Callback<Enrollment> {
+        @Override
+        void onSuccess(RichConsent consentDetails) {
+          // we have the consent details 
+        }
+
+        @Override
+        void onFailure(Throwable exception) {
+          if (exception instanceof GuardianException) {
+            GuardianException guardianException = (GuardianException) exception;
+            if (guardianException.isResourceNotFound()) {
+              // there is no consent associated with the tranaction
+            }
+          }
+          // something went wrong 
+        }
+      });
+}
+```
+
 ## What is Auth0?
 
 Auth0 helps you to:
 
-* Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders),
-either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce,
-among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory,
-ADFS or any SAML Identity Provider**.
-* Add authentication through more traditional
-**[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
-* Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with
-the same user.
-* Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and
-**flow the user identity** securely.
-* Analytics of how, when and where users are logging in.
-* Pull data from other sources and add it to the user profile, through
-[JavaScript rules](https://docs.auth0.com/rules).
+- Add authentication with [multiple authentication sources](https://docs.auth0.com/identityproviders),
+  either social like **Google, Facebook, Microsoft Account, LinkedIn, GitHub, Twitter, Box, Salesforce,
+  among others**, or enterprise identity systems like **Windows Azure AD, Google Apps, Active Directory,
+  ADFS or any SAML Identity Provider**.
+- Add authentication through more traditional
+  **[username/password databases](https://docs.auth0.com/mysql-connection-tutorial)**.
+- Add support for **[linking different user accounts](https://docs.auth0.com/link-accounts)** with
+  the same user.
+- Support for generating signed [Json Web Tokens](https://docs.auth0.com/jwt) to call your APIs and
+  **flow the user identity** securely.
+- Analytics of how, when and where users are logging in.
+- Pull data from other sources and add it to the user profile, through
+  [JavaScript rules](https://docs.auth0.com/rules).
 
 ## Create a free account in Auth0
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ OEM-specific builds. The example given above and that used in the sample applica
 which may not be suitable for production applications. It is recommended that you follow [OWASP guidelines
 for Android Cryptographic APIs](https://mas.owasp.org/MASTG/0x05e-Testing-Cryptography/) for your implementation.
 
-As of version 1.9.0 the public key used for enrollment was added to the Enrollment Interface as it is
+As of version 0.9.0 the public key used for enrollment was added to the Enrollment Interface as it is
 required for [fetching rich-consent details](#fetch-rich-consent-details). For new installs,
 this is not a a concern. For enrollments created prior to this version, depending on implementation, 
 this key may or may not have been stored with the enrollment information. If this key was discarded, 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ implementation 'com.auth0.android:guardian:0.8.1'
 tenant/url.
 
 ```java
-Uri url = Uri.parse("https://<AUTH0_TENANT_DOMAIN>/appliance-mfa");
+Uri url = Uri.parse("https://<tenant>.<region>.auth0.com");
 
 Guardian guardian = new Guardian.Builder()
         .url(url)
@@ -52,7 +52,7 @@ Guardian guardian = new Guardian.Builder()
 alternatively you can use the custom domain if you configured one
 
 ```java
-Uri url = Uri.parse("https://<CUSTOM_DOMAIN>/appliance-mfa");
+Uri url = Uri.parse("<custom>");
 
 Guardian guardian = new Guardian.Builder()
         .url(url)

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ The `deviceName` and `fcmToken` are data that you must provide:
 
 #### A note about key generation
 
-The Guardian SDK does not provided methods for generating and storing cryptographic keys used for enrollment,
-as this is an application specific concern and could vary between targeted versions of Android and the 
+The Guardian SDK does not provide methods for generating and storing cryptographic keys used for enrollment
+as this is an application specific concern and could vary between targeted versions of Android and 
 OEM-specific builds. The example given above and that used in the sample application is a naive implementation 
 which may not be suitable for production applications. It is recommended that you follow [OWASP guidelines
 for Android Cryptographic APIs](https://mas.owasp.org/MASTG/0x05e-Testing-Cryptography/) for your implementation.
@@ -132,7 +132,7 @@ required for [fetching rich-consent details](#fetch-rich-consent-details). For n
 this is not a a concern. For enrollments created prior to this version, depending on implementation, 
 this key may or may not have been stored with the enrollment information. If this key was discarded, 
 it may be possible to reconstruct from the stored signing key. The sample app provides 
-[an example](app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java#L194) of this. If 
+[an example](app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java#L188) of this. If 
 this is not possible, devices will require re-enrollment to make use of this functionality.
 
 ### Unenroll

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.auth0.guardian.sample"
-        minSdkVersion 22
+        minSdkVersion 26
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"
@@ -40,4 +40,6 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.3.1'
     // ZXing QR decoder deps
     implementation 'com.google.zxing:core:3.5.0'
+
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.76'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.auth0.guardian.sample'
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.auth0.guardian.sample"
-        minSdkVersion 26
+        minSdkVersion 22
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     // ZXing QR decoder deps
     implementation 'com.google.zxing:core:3.5.0'
 
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.76'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,12 @@
 
         </activity>
 
+        <activity
+            android:name=".NotificationWithConsentDetailsActivity"
+            android:label="@string/title_notification_with_consent_details">
+
+        </activity>
+
         <!-- [START FCM services] -->
 
         <service android:name=".fcm.FcmListenerService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.auth0.guardian.sample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/com/auth0/guardian/sample/Constants.java
+++ b/app/src/main/java/com/auth0/guardian/sample/Constants.java
@@ -26,4 +26,5 @@ public class Constants {
 
     public static final String ENROLLMENT = "com.auth0.guardian.sample.Constants.ENROLLMENT";
     public static final String NOTIFICATION = "com.auth0.guardian.sample.Constants.NOTIFICATION";
+    public static final String CONSENT = "com.auth0.guardian.sample.Constants.CONSENT";
 }

--- a/app/src/main/java/com/auth0/guardian/sample/EnrollActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/EnrollActivity.java
@@ -169,7 +169,7 @@ public class EnrollActivity extends AppCompatActivity implements CaptureView.Lis
         }
 
         guardian = new Guardian.Builder()
-                .url(Uri.parse(getString(R.string.guardian_url)))
+                .url(Uri.parse(getString(R.string.tenant_url)))
                 .enableLogging()
                 .build();
     }

--- a/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
@@ -91,7 +91,7 @@ public class MainActivity extends AppCompatActivity implements FcmUtils.FcmToken
         eventBus.register(this);
 
         guardian = new Guardian.Builder()
-                .url(Uri.parse(getString(R.string.guardian_url)))
+                .url(Uri.parse(getString(R.string.tenant_url)))
                 .enableLogging()
                 .build();
 

--- a/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/MainActivity.java
@@ -223,8 +223,9 @@ public class MainActivity extends AppCompatActivity implements FcmUtils.FcmToken
     }
 
     private void onPushNotificationReceived(ParcelableNotification notification) {
-        Intent intent = NotificationActivity
-                .getStartIntent(this, notification, enrollment);
+        Intent intent = notification.getTransactionLinkingId() != null ?
+                NotificationWithConsentDetailsActivity.getStartIntent(this, notification, enrollment) :
+                NotificationActivity.getStartIntent(this, notification, enrollment);
         startActivity(intent);
     }
 

--- a/app/src/main/java/com/auth0/guardian/sample/NotificationActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/NotificationActivity.java
@@ -69,7 +69,7 @@ public class NotificationActivity extends AppCompatActivity {
         setContentView(R.layout.activity_notification);
 
         guardian = new Guardian.Builder()
-                .url(Uri.parse(getString(R.string.guardian_url)))
+                .url(Uri.parse(getString(R.string.tenant_url)))
                 .enableLogging()
                 .build();
 

--- a/app/src/main/java/com/auth0/guardian/sample/NotificationWithConsentDetailsActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/NotificationWithConsentDetailsActivity.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2016 Auth0 (http://auth0.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.auth0.guardian.sample;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.auth0.android.guardian.sdk.Guardian;
+import com.auth0.android.guardian.sdk.ParcelableNotification;
+import com.auth0.android.guardian.sdk.model.RichConsent;
+import com.auth0.android.guardian.sdk.networking.Callback;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+public class NotificationWithConsentDetailsActivity extends AppCompatActivity {
+
+    private static final String TAG = NotificationWithConsentDetailsActivity.class.getName();
+
+    private TextView bindingMessageText;
+    private TextView scopeText;
+    private TextView dateText;
+
+    private Guardian guardian;
+    private ParcelableEnrollment enrollment;
+    private ParcelableNotification notification;
+    private RichConsent consentDetails;
+
+    static Intent getStartIntent(@NonNull Context context,
+                                 @NonNull ParcelableNotification notification,
+                                 @NonNull ParcelableEnrollment enrollment) {
+        if (!enrollment.getId().equals(notification.getEnrollmentId())) {
+            final String message = String.format("Notification doesn't match enrollment (%s != %s)",
+                    notification.getEnrollmentId(), enrollment.getId());
+            throw new IllegalArgumentException(message);
+        }
+
+        Intent intent = new Intent(context, NotificationWithConsentDetailsActivity.class);
+        intent.putExtra(Constants.ENROLLMENT, enrollment);
+        intent.putExtra(Constants.NOTIFICATION, notification);
+        return intent;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_notification_with_consent_details);
+
+        guardian = new Guardian.Builder()
+                .url(Uri.parse(getString(R.string.guardian_url)))
+                .enableLogging()
+                .build();
+
+        Intent intent = getIntent();
+        enrollment = intent.getParcelableExtra(Constants.ENROLLMENT);
+        notification = intent.getParcelableExtra(Constants.NOTIFICATION);
+
+        setupUI();
+        updateUI();
+
+        try {
+            guardian.fetchConsent(notification, enrollment).start(new Callback<RichConsent>() {
+                @Override
+                public void onSuccess(RichConsent response) {
+                    consentDetails = response;
+                    updateUI();
+                }
+
+                @Override
+                public void onFailure(Throwable exception) {
+                    Log.e(TAG, "Error obtaining consent details", exception);
+                }
+            });
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            Log.e(TAG, "Error requesting consent details", e);
+        }
+
+    }
+
+    private void setupUI() {
+        bindingMessageText = (TextView) findViewById(R.id.bindingMessage);
+        scopeText = (TextView) findViewById(R.id.scope);
+        dateText = (TextView) findViewById(R.id.dateText);
+
+        Button rejectButton = (Button) findViewById(R.id.rejectButton);
+        assert rejectButton != null;
+        rejectButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                rejectRequested();
+            }
+        });
+
+        Button allowButton = (Button) findViewById(R.id.allowButton);
+        assert allowButton != null;
+        allowButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                allowRequested();
+            }
+        });
+    }
+
+    private void updateUI() {
+        if (consentDetails != null) {
+            bindingMessageText.setText(consentDetails.requested_details.binding_message);
+            scopeText.setText(String.join(", ", consentDetails.requested_details.scope));
+        } else {
+            bindingMessageText.setText("N/A");
+            scopeText.setText("N/A");
+        }
+        dateText.setText(notification.getDate().toString());
+    }
+
+    private void rejectRequested() {
+        guardian
+                .reject(notification, enrollment)
+                .start(new DialogCallback<>(this,
+                        R.string.progress_title_please_wait,
+                        R.string.progress_message_reject,
+                        new Callback<Void>() {
+                            @Override
+                            public void onSuccess(Void response) {
+                                finish();
+                            }
+
+                            @Override
+                            public void onFailure(Throwable exception) {
+
+                            }
+                        }));
+    }
+
+    private void allowRequested() {
+        guardian
+                .allow(notification, enrollment)
+                .start(new DialogCallback<>(this,
+                        R.string.progress_title_please_wait,
+                        R.string.progress_message_allow,
+                        new Callback<Void>() {
+                            @Override
+                            public void onSuccess(Void response) {
+                                finish();
+                            }
+
+                            @Override
+                            public void onFailure(Throwable exception) {
+
+                            }
+                        }));
+    }
+}

--- a/app/src/main/java/com/auth0/guardian/sample/NotificationWithConsentDetailsActivity.java
+++ b/app/src/main/java/com/auth0/guardian/sample/NotificationWithConsentDetailsActivity.java
@@ -50,7 +50,7 @@ public class NotificationWithConsentDetailsActivity extends AppCompatActivity {
         setContentView(R.layout.activity_notification_with_consent_details);
 
         guardian = new Guardian.Builder()
-                .url(Uri.parse(getString(R.string.guardian_url)))
+                .url(Uri.parse(getString(R.string.tenant_url)))
                 .enableLogging()
                 .build();
 

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java
@@ -172,7 +172,7 @@ public class ParcelableEnrollment implements Enrollment, Parcelable {
         try {
             if (publicKey == null || publicKey.isEmpty()) {
                 // For backwards-compatibility with enrollments encoded without a public key in
-                // version 0.8.1 and before of the Guardian.Android SDK
+                // version 1.8.1 and before of the Guardian.Android SDK
                 return getPublicKeyFromSigningKey();
             }
 

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableEnrollment.java
@@ -171,8 +171,8 @@ public class ParcelableEnrollment implements Enrollment, Parcelable {
     public PublicKey getPublicKey() {
         try {
             if (publicKey == null || publicKey.isEmpty()) {
-                // For backwards-compatibility with enrollments encoded without a public key in
-                // version 1.8.1 and before of the Guardian.Android SDK
+                // For backwards-compatibility with enrollments encoded without a public key
+                // prior to version 0.9.0 of the Guardian.Android SDK
                 return getPublicKeyFromSigningKey();
             }
 

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsent.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsent.java
@@ -57,21 +57,25 @@ public class ParcelableRichConsent implements RichConsent, Parcelable {
         return JSON.toJson(this);
     }
 
+    @NonNull
     @Override
     public String getId() {
         return id;
     }
 
+    @NonNull
     @Override
     public RichConsentRequestedDetails getRequestedDetails() {
         return requestedDetails;
     }
 
+    @NonNull
     @Override
     public String getCreatedAt() {
         return createdAt;
     }
 
+    @NonNull
     @Override
     public String getExpiresAt() {
         return expiresAt;

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsent.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsent.java
@@ -1,0 +1,92 @@
+package com.auth0.guardian.sample;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+
+import com.auth0.android.guardian.sdk.RichConsent;
+import com.auth0.android.guardian.sdk.RichConsentRequestedDetails;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public class ParcelableRichConsent implements RichConsent, Parcelable {
+    public static final Creator<ParcelableRichConsent> CREATOR = new Creator<ParcelableRichConsent>() {
+        @Override
+        public ParcelableRichConsent createFromParcel(Parcel in) {
+            return new ParcelableRichConsent(in);
+        }
+
+        @Override
+        public ParcelableRichConsent[] newArray(int size) {
+            return new ParcelableRichConsent[size];
+        }
+    };
+
+    private static final Gson JSON = new GsonBuilder().create();
+
+    @SerializedName("id")
+    private final String id;
+    @SerializedName("requested_details")
+    private final ParcelableRichConsentRequestedDetails requestedDetails;
+    @SerializedName("created_at")
+    private final String createdAt;
+    @SerializedName("expires_at")
+    private final String expiresAt;
+
+    public ParcelableRichConsent(RichConsent richConsent) {
+        this.id = richConsent.getId();
+        this.createdAt = this.getCreatedAt();
+        this.expiresAt = this.getExpiresAt();
+        this.requestedDetails = new ParcelableRichConsentRequestedDetails(richConsent.getRequestedDetails());
+    }
+
+    protected ParcelableRichConsent(Parcel in) {
+        id = in.readString();
+        createdAt = in.readString();
+        expiresAt = in.readString();
+        requestedDetails = in.readParcelable(ParcelableRichConsentRequestedDetails.class.getClassLoader());
+    }
+
+    public static ParcelableEnrollment fromJSON(String json) {
+        return JSON.fromJson(json, ParcelableEnrollment.class);
+    }
+
+    public String toJSON() {
+        return JSON.toJson(this);
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public RichConsentRequestedDetails getRequestedDetails() {
+        return requestedDetails;
+    }
+
+    @Override
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String getExpiresAt() {
+        return expiresAt;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(id);
+        dest.writeString(createdAt);
+        dest.writeString(expiresAt);
+        dest.writeParcelable(requestedDetails, flags);
+    }
+}

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsentRequestedDetails.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsentRequestedDetails.java
@@ -51,11 +51,13 @@ public class ParcelableRichConsentRequestedDetails implements RichConsentRequest
         return JSON.toJson(this);
     }
 
+    @NonNull
     @Override
     public String getAudience() {
         return audience;
     }
 
+    @NonNull
     @Override
     public String[] getScope() {
         return scope;

--- a/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsentRequestedDetails.java
+++ b/app/src/main/java/com/auth0/guardian/sample/ParcelableRichConsentRequestedDetails.java
@@ -1,0 +1,80 @@
+package com.auth0.guardian.sample;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+
+import com.auth0.android.guardian.sdk.RichConsentRequestedDetails;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+
+public class ParcelableRichConsentRequestedDetails implements RichConsentRequestedDetails, Parcelable {
+    public static final Creator<ParcelableRichConsentRequestedDetails> CREATOR = new Creator<ParcelableRichConsentRequestedDetails>() {
+        @Override
+        public ParcelableRichConsentRequestedDetails createFromParcel(Parcel in) {
+            return new ParcelableRichConsentRequestedDetails(in);
+        }
+
+        @Override
+        public ParcelableRichConsentRequestedDetails[] newArray(int size) {
+            return new ParcelableRichConsentRequestedDetails[size];
+        }
+    };
+    private static final Gson JSON = new GsonBuilder().create();
+
+    @SerializedName("audience")
+    private final String audience;
+    @SerializedName("scope")
+    private final String[] scope;
+    @SerializedName("bindingMessage")
+    private final String bindingMessage;
+
+    public ParcelableRichConsentRequestedDetails(RichConsentRequestedDetails requestedDetails) {
+        audience = requestedDetails.getAudience();
+        scope = requestedDetails.getScope();
+        bindingMessage = requestedDetails.getBindingMessage();
+    }
+
+    protected ParcelableRichConsentRequestedDetails(Parcel in) {
+        audience = in.readString();
+        scope = in.createStringArray();
+        bindingMessage = in.readString();
+    }
+
+    public static ParcelableEnrollment fromJSON(String json) {
+        return JSON.fromJson(json, ParcelableEnrollment.class);
+    }
+
+    public String toJSON() {
+        return JSON.toJson(this);
+    }
+
+    @Override
+    public String getAudience() {
+        return audience;
+    }
+
+    @Override
+    public String[] getScope() {
+        return scope;
+    }
+
+    @Override
+    public String getBindingMessage() {
+        return bindingMessage;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int flags) {
+        dest.writeString(audience);
+        dest.writeStringArray(scope);
+        dest.writeString(bindingMessage);
+    }
+}

--- a/app/src/main/res/layout/activity_notification_with_consent_details.xml
+++ b/app/src/main/res/layout/activity_notification_with_consent_details.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".NotificationWithConsentDetailsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:theme="@style/AppTheme.ToolBar"
+            app:navigationIcon="@mipmap/ic_launcher"
+            app:popupTheme="@style/AppTheme.Popup"
+            app:title="@string/title_notification" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <RelativeLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textView3"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="30sp"
+                android:text="Do you approve this transaction?"
+                android:textSize="34sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Binding Message"
+                android:textSize="12sp"
+                android:theme="@style/Label.Header" />
+
+            <TextView
+                android:id="@+id/bindingMessage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:textSize="12sp"
+                android:theme="@style/Label"
+                tools:text="ABC-123-DEF" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Requested scope"
+                android:textSize="12sp"
+                android:theme="@style/Label.Header" />
+
+            <TextView
+                android:id="@+id/scope"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:textSize="12sp"
+                android:theme="@style/Label"
+                tools:text="read:foo" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Date"
+                android:textSize="12sp"
+                android:theme="@style/Label.Header" />
+
+            <TextView
+                android:id="@+id/dateText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="36dp"
+                android:textSize="12sp"
+                android:theme="@style/Label"
+                tools:text="Today at 18:56:21" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true">
+
+            <Button
+                android:id="@+id/rejectButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Deny" />
+
+            <Button
+                android:id="@+id/allowButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Allow" />
+
+        </LinearLayout>
+
+    </RelativeLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/guardian.xml
+++ b/app/src/main/res/values/guardian.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="guardian_url">https://custom-sns-app-test.guardian.auth0.com</string>
+    <string name="tenant_url">https://guardian-demo.us.auth0.com</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="title_main">Guardian SDK</string>
     <string name="title_enroll">Enroll account</string>
     <string name="title_notification">Authentication request</string>
+    <string name="title_notification_with_consent_details">Authentication With Consent Details request</string>
     <string name="progress_title_please_wait">Please wait</string>
     <string name="progress_message_unenroll">Trying to unenroll your account…</string>
     <string name="progress_message_reject">Trying to reject the authentication request…</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.google.gms:google-services:4.3.13'
+        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.google.gms:google-services:4.4.2'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,8 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -4,9 +4,9 @@ plugins {
 
 android {
     defaultConfig {
-        compileSdk 34
-        minSdkVersion 26
-        targetSdkVersion 34
+        compileSdk 33
+        minSdkVersion 22
+        targetSdkVersion 33
         buildConfigField "String", "VERSION_NAME", "\"${project.version}\""
     }
     buildTypes {

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     // JWT signing/verification
-    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'com.auth0:java-jwt:4.5.0'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver'
     // Mockito

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     implementation platform('com.squareup.okhttp3:okhttp-bom:4.10.0')
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
+    // JWT signing/verification
+    implementation 'com.auth0:java-jwt:4.0.0'
+
     testImplementation 'com.squareup.okhttp3:mockwebserver'
     // Mockito
     testImplementation 'org.mockito:mockito-core:4.6.1'
@@ -48,8 +51,6 @@ dependencies {
     // Awaitility
     testImplementation 'org.awaitility:awaitility:4.2.0'
     // Robolectric
-    testImplementation 'org.robolectric:robolectric:4.4'
-    // JWT verification
-    testImplementation 'com.auth0:java-jwt:4.0.0'
+    testImplementation 'org.robolectric:robolectric:4.14'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     // JWT signing/verification
-    implementation 'com.auth0:java-jwt:4.0.0'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver'
     // Mockito

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -1,35 +1,13 @@
 plugins {
-    id "com.auth0.gradle.oss-library.android" version "0.17.1"
-}
-
-logger.lifecycle("Using version ${version} for ${name}")
-
-oss {
-    name 'Guardian.Android'
-    repository 'Guardian.Android'
-    organization 'auth0'
-    description 'Android toolkit for Auth0 Guardian API'
-
-    developers {
-        auth0 {
-            displayName = 'Auth0'
-            email = 'oss@auth0.com'
-        }
-        nikolaseu {
-            displayName = 'Nicolas Ulrich'
-            email = 'nicolas.ulrich@auth0.com'
-        }
-    }
+    id 'com.android.library'
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 22
-        targetSdkVersion 33
-        versionCode 1
-        versionName project.version
+        minSdkVersion 15
+        targetSdkVersion 30
         buildConfigField "String", "VERSION_NAME", "\"${project.version}\""
     }
     buildTypes {
@@ -47,19 +25,19 @@ android {
             all {
                 maxHeapSize = "1024m"
             }
-            includeAndroidResources = true
         }
     }
+    namespace 'com.auth0.android.guardian.sdk'
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Annotations (@NonNull etc)
-    implementation 'androidx.annotation:annotation:1.4.0'
+    implementation 'androidx.annotation:annotation:1.9.1'
     // Gson
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
     // OkHttp
-    implementation 'com.squareup.okhttp3:okhttp-bom:4.10.0'
+    implementation platform('com.squareup.okhttp3:okhttp-bom:4.10.0')
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     testImplementation 'com.squareup.okhttp3:mockwebserver'
@@ -73,4 +51,5 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.4'
     // JWT verification
     testImplementation 'com.auth0:java-jwt:4.0.0'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 android {
     defaultConfig {
+        compileSdk 34
         minSdkVersion 26
         targetSdkVersion 34
         buildConfigField "String", "VERSION_NAME", "\"${project.version}\""

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -3,11 +3,9 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 30
+        minSdkVersion 26
+        targetSdkVersion 34
         buildConfigField "String", "VERSION_NAME", "\"${project.version}\""
     }
     buildTypes {

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/EnrollRequest.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/EnrollRequest.java
@@ -104,6 +104,6 @@ class EnrollRequest implements GuardianAPIRequest<Enrollment> {
         }
 
         return new GuardianEnrollment(userId, totpPeriod, totpDigits, totpAlgorithm,
-                totpSecret, enrollmentId, device, deviceToken, deviceKeyPair.getPrivate());
+                totpSecret, enrollmentId, device, deviceToken, deviceKeyPair.getPrivate(), deviceKeyPair.getPublic());
     }
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
@@ -27,6 +27,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.security.PrivateKey;
+import java.security.PublicKey;
 
 /**
  * The representation of a Guardian Enrollment
@@ -128,4 +129,7 @@ public interface Enrollment {
      */
     @NonNull
     PrivateKey getSigningKey();
+
+    @NonNull
+    PublicKey getPublicKey();
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
@@ -132,7 +132,7 @@ public interface Enrollment {
 
     /**
      * The public key used for enrollment.
-     * @since Guardian SDK Version 1.9.0
+     * @since Guardian SDK Version 0.9.0
      * @see <a href="https://github.com/auth0/Guardian.Android#a-note-about-key-generation">A note about key generation</a>
      *
      * @return the RSA public key

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Enrollment.java
@@ -130,6 +130,13 @@ public interface Enrollment {
     @NonNull
     PrivateKey getSigningKey();
 
+    /**
+     * The public key used for enrollment.
+     * @since Guardian SDK Version 1.9.0
+     * @see <a href="https://github.com/auth0/Guardian.Android#a-note-about-key-generation">A note about key generation</a>
+     *
+     * @return the RSA public key
+     */
     @NonNull
     PublicKey getPublicKey();
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -28,11 +28,9 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.otp.TOTP;
 import com.auth0.android.guardian.sdk.otp.utils.Base32;
 
-import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -155,21 +155,7 @@ public class Guardian {
      * @return the request
      */
     public GuardianAPIRequest<RichConsent> fetchConsent(@NonNull Notification notification, @NonNull Enrollment enrollment) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        PublicKey publicKey = getPublicKeyFromSigningKey(enrollment.getSigningKey());
-        return fetchConsent(notification, enrollment, publicKey);
-    }
-
-    /**
-     * Fetches the rich consent record linked to the transaction.
-     *
-     * @param notification the push notification
-     * @param enrollment   the device enrollment
-     * @param publicKey    the enrollment public key
-     *
-     * @return  the rich consents api request
-     */
-    public GuardianAPIRequest<RichConsent> fetchConsent(@NonNull Notification notification, @NonNull Enrollment enrollment, @NonNull PublicKey publicKey) {
-        return client.richConsents(enrollment.getSigningKey(), publicKey)
+        return client.richConsents(enrollment.getSigningKey(), enrollment.getPublicKey())
                 .fetch(notification.getTransactionLinkingId(), notification.getTransactionToken());
     }
 
@@ -231,17 +217,6 @@ public class Guardian {
         } catch (Base32.DecodingException e) {
             throw new IllegalArgumentException(
                     "Enrollment's secret is not a valid Base32 encoded TOTP secret", e);
-        }
-    }
-
-    private PublicKey getPublicKeyFromSigningKey(PrivateKey signingKey) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-        if (signingKey instanceof RSAPrivateCrtKey) {
-            RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) signingKey;
-            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(rsaPrivateKey.getModulus(), rsaPrivateKey.getPublicExponent());
-            return keyFactory.generatePublic(publicKeySpec);
-        } else {
-            throw new IllegalArgumentException("Not an RSA private key.");
         }
     }
 

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -28,10 +28,12 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.otp.TOTP;
 import com.auth0.android.guardian.sdk.otp.utils.Base32;
 
 import java.security.KeyPair;
+import java.security.PublicKey;
 import java.util.Map;
 
 /**
@@ -136,6 +138,11 @@ public class Guardian {
     public GuardianAPIRequest<Void> reject(@NonNull Notification notification,
                                            @NonNull Enrollment enrollment) {
         return reject(notification, enrollment, null);
+    }
+
+    public GuardianAPIRequest<RichConsent> fetchConsent(@NonNull Notification notification, @NonNull Enrollment enrollment, @NonNull PublicKey publicKey) {
+        return client.richConsents(enrollment.getSigningKey(), publicKey)
+                .fetch(notification.getTransactionLinkingId(), notification.getTransactionToken());
     }
 
     GuardianAPIClient getAPIClient() {

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -250,7 +250,7 @@ public class GuardianAPIClient {
      * @param publicKey  the enrollment public key
      * @return an API client for rich consents
      */
-    public RichConsentsAPIClient richConsents(PrivateKey privateKey, PublicKey publicKey) {
+    public RichConsentsAPIClient richConsents(@NonNull PrivateKey privateKey, @NonNull PublicKey publicKey) {
         // According to the Guardian SDK guidelines, developers must provide either the Guardian domain
         // or the canonical domain including the `/appliance-mfa` path. However, since Rich Consents is
         // not an MFA API endpoint, preserving this path will not work.
@@ -264,7 +264,7 @@ public class GuardianAPIClient {
             guardianUrl = guardianUrl.replace(".guardian.", ".");
         }
         final HttpUrl url = HttpUrl.parse(guardianUrl);
-        return new RichConsentsAPIClient(requestFactory, url, privateKey, publicKey);
+        return new RichConsentsAPIClient(requestFactory, url, privateKey, publicKey, clientInfo.telemetryInfo);
     }
 
     private String createBasicJWT(@NonNull PrivateKey privateKey,

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -242,6 +242,28 @@ public class GuardianAPIClient {
         return new DeviceAPIClient(requestFactory, baseUrl, deviceIdentifier, token);
     }
 
+    /**
+     * Returns an API client to fetch transaction's rich consent record.
+     *
+     * @param privateKey    the enrollment signing key
+     * @param publicKey     the enrollment public key
+     * @return an API client for rich consents
+     */
+    public RichConsentsAPIClient richConsents(PrivateKey privateKey, PublicKey publicKey) {
+        // According to the Guardian SDK guidelines, developers must provide either the Guardian domain
+        // or the canonical domain including the `/appliance-mfa` path. However, since Rich Consents is
+        // not an MFA API endpoint, preserving this path will not work.
+        // As a temporary solution, the `/appliance-mfa` path is stripped from the base URL.
+        // IMPORTANT: Rich Consents will not function correctly when using the Guardian domain until
+        // a long term solution is implemented.
+        String guardianUrl = baseUrl.toString();
+        if (guardianUrl.contains("/appliance-mfa")) {
+            guardianUrl = guardianUrl.replace("/appliance-mfa", "");
+        }
+        final HttpUrl url = HttpUrl.parse(guardianUrl);
+        return new RichConsentsAPIClient(requestFactory, url, privateKey, publicKey);
+    }
+
     private String createBasicJWT(@NonNull PrivateKey privateKey,
                                   @NonNull String audience,
                                   @NonNull String deviceIdentifier,

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianAPIClient.java
@@ -260,6 +260,7 @@ public class GuardianAPIClient {
         if (guardianUrl.contains("/appliance-mfa")) {
             guardianUrl = guardianUrl.replace("/appliance-mfa", "");
         }
+        // TODO: remove .guardian.
         final HttpUrl url = HttpUrl.parse(guardianUrl);
         return new RichConsentsAPIClient(requestFactory, url, privateKey, publicKey);
     }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianEnrollment.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianEnrollment.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.security.PrivateKey;
+import java.security.PublicKey;
 
 class GuardianEnrollment implements Enrollment {
 
@@ -40,6 +41,7 @@ class GuardianEnrollment implements Enrollment {
     private final String notificationToken;
     private final String deviceToken;
     private final PrivateKey privateKey;
+    private final PublicKey publicKey;
 
     GuardianEnrollment(@NonNull String userId,
                        @Nullable Integer period,
@@ -49,7 +51,8 @@ class GuardianEnrollment implements Enrollment {
                        @NonNull String enrollmentId,
                        @NonNull CurrentDevice device,
                        @NonNull String deviceToken,
-                       @NonNull PrivateKey privateKey) {
+                       @NonNull PrivateKey privateKey,
+                       @NonNull PublicKey publicKey) {
         this.userId = userId;
         this.period = period;
         this.digits = digits;
@@ -61,6 +64,7 @@ class GuardianEnrollment implements Enrollment {
         this.notificationToken = device.getNotificationToken();
         this.deviceToken = deviceToken;
         this.privateKey = privateKey;
+        this.publicKey = publicKey;
     }
 
     @NonNull
@@ -127,5 +131,11 @@ class GuardianEnrollment implements Enrollment {
     @Override
     public PrivateKey getSigningKey() {
         return privateKey;
+    }
+
+    @NonNull
+    @Override
+    public PublicKey getPublicKey() {
+        return publicKey;
     }
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianException.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianException.java
@@ -37,24 +37,37 @@ public class GuardianException extends RuntimeException {
 
     private final Map<String, Object> errorResponse;
     private final String errorCode;
+    private final int statusCode;
 
     public GuardianException(String detailMessage) {
         super(detailMessage);
+        this.statusCode = -1;
         this.errorCode = null;
         this.errorResponse = null;
     }
 
-    public GuardianException(String detailMessage, Throwable throwable) {
+    public GuardianException(String detailMessage, int statusCode, Throwable throwable) {
         super(detailMessage, throwable);
         this.errorCode = null;
         this.errorResponse = null;
+        this.statusCode = statusCode;
     }
 
-    public GuardianException(Map<String, Object> errorResponse) {
+    public GuardianException(String detailMessage, Throwable throwable) {
+        this(detailMessage, -1, throwable);
+    }
+
+    public GuardianException(Map<String, Object> errorResponse, int statusCode) {
         super((String) errorResponse.get("error"));
         this.errorCode = (String) errorResponse.get("errorCode");
         this.errorResponse = errorResponse;
+        this.statusCode = statusCode;
     }
+
+    public GuardianException(Map<String, Object> errorResponse) {
+        this(errorResponse, -1);
+    }
+
 
     /**
      * Returns the `errorCode` value, if available.
@@ -64,6 +77,15 @@ public class GuardianException extends RuntimeException {
     @Nullable
     public String getErrorCode() {
         return errorCode;
+    }
+
+    /**
+     * Returns the HTTP code of the error response, if available
+     *
+     * @return the http status code, or -1
+     */
+    public int getStatusCode() {
+        return statusCode;
     }
 
     /**
@@ -90,8 +112,7 @@ public class GuardianException extends RuntimeException {
      * @return true if the error is caused by the enrollment being invalid or not found
      */
     public boolean isEnrollmentNotFound() {
-        return ERROR_DEVICE_ACCOUNT_NOT_FOUND.equals(errorCode)
-                || ERROR_ENROLLMENT_NOT_FOUND.equals(errorCode);
+        return ERROR_DEVICE_ACCOUNT_NOT_FOUND.equals(errorCode) || ERROR_ENROLLMENT_NOT_FOUND.equals(errorCode);
     }
 
     /**
@@ -110,6 +131,15 @@ public class GuardianException extends RuntimeException {
      */
     public boolean isLoginTransactionNotFound() {
         return ERROR_LOGIN_TRANSACTION_NOT_FOUND.equals(errorCode);
+    }
+
+    /**
+     * Whether the error is caused by the requested resource being not found.
+     *
+     * @return true if error is caused by the requested resource being not found.
+     */
+    public boolean isResourceNotFound() {
+        return statusCode == 404 || (errorCode != null && errorCode.matches("(?i).*not_found.*"));
     }
 
     @Override

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsent.java
@@ -1,0 +1,41 @@
+package com.auth0.android.guardian.sdk;
+
+import com.google.gson.annotations.SerializedName;
+
+public class GuardianRichConsent implements RichConsent {
+    private final String id;
+    @SerializedName("requested_details")
+    private final GuardianRichConsentRequestedDetails requestedDetails;
+    @SerializedName("created_at")
+    private final String createdAt;
+    @SerializedName("expires_at")
+    private final String expiresAt;
+
+    public GuardianRichConsent(String id, GuardianRichConsentRequestedDetails requestedDetails, String createdAt, String expiresAt) {
+        this.id = id;
+        this.requestedDetails = requestedDetails;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public RichConsentRequestedDetails getRequestedDetails() {
+        return requestedDetails;
+    }
+
+    @Override
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String getExpiresAt() {
+        return expiresAt;
+    }
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsent.java
@@ -1,5 +1,7 @@
 package com.auth0.android.guardian.sdk;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 public class GuardianRichConsent implements RichConsent {
@@ -19,21 +21,25 @@ public class GuardianRichConsent implements RichConsent {
     }
 
 
+    @NonNull
     @Override
     public String getId() {
         return id;
     }
 
+    @NonNull
     @Override
     public RichConsentRequestedDetails getRequestedDetails() {
         return requestedDetails;
     }
 
+    @NonNull
     @Override
     public String getCreatedAt() {
         return createdAt;
     }
 
+    @NonNull
     @Override
     public String getExpiresAt() {
         return expiresAt;

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsentRequestedDetails.java
@@ -1,5 +1,7 @@
 package com.auth0.android.guardian.sdk;
 
+import androidx.annotation.NonNull;
+
 import com.google.gson.annotations.SerializedName;
 
 public class GuardianRichConsentRequestedDetails implements RichConsentRequestedDetails {
@@ -18,11 +20,13 @@ public class GuardianRichConsentRequestedDetails implements RichConsentRequested
     }
 
 
+    @NonNull
     @Override
     public String getAudience() {
         return audience;
     }
 
+    @NonNull
     @Override
     public String[] getScope() {
         return scope;

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/GuardianRichConsentRequestedDetails.java
@@ -1,0 +1,35 @@
+package com.auth0.android.guardian.sdk;
+
+import com.google.gson.annotations.SerializedName;
+
+public class GuardianRichConsentRequestedDetails implements RichConsentRequestedDetails {
+    private final String audience;
+    private final String[] scope;
+    @SerializedName("binding_message")
+    private final String bindingMessage;
+
+    public GuardianRichConsentRequestedDetails(
+            String audience,
+            String[] scope,
+            String bindingMessage) {
+        this.bindingMessage = bindingMessage;
+        this.audience = audience;
+        this.scope = scope;
+    }
+
+
+    @Override
+    public String getAudience() {
+        return audience;
+    }
+
+    @Override
+    public String[] getScope() {
+        return scope;
+    }
+
+    @Override
+    public String getBindingMessage() {
+        return bindingMessage;
+    }
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsent.java
@@ -1,0 +1,11 @@
+package com.auth0.android.guardian.sdk;
+
+public interface RichConsent {
+    String getId();
+
+    RichConsentRequestedDetails getRequestedDetails();
+
+    String getCreatedAt();
+
+    String getExpiresAt();
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsent.java
@@ -1,11 +1,29 @@
 package com.auth0.android.guardian.sdk;
 
+import androidx.annotation.NonNull;
+
 public interface RichConsent {
+    /**
+     * Consent record id
+     */
+    @NonNull
     String getId();
 
+    /**
+     * Requested details
+     */
+    @NonNull
     RichConsentRequestedDetails getRequestedDetails();
 
+    /**
+     * When the consent was created
+     */
+    @NonNull
     String getCreatedAt();
 
+    /**
+     * When the consent expires
+     */
+    @NonNull
     String getExpiresAt();
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentRequestedDetails.java
@@ -1,8 +1,23 @@
 package com.auth0.android.guardian.sdk;
 
+import androidx.annotation.NonNull;
+
 public interface RichConsentRequestedDetails {
+    /**
+     * Requested audience
+     */
+    @NonNull
     String getAudience();
+
+    /**
+     * Requested scopes
+     */
+    @NonNull
     String[] getScope();
+
+    /**
+     * CIBA binding message
+     */
     String getBindingMessage();
 }
 

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentRequestedDetails.java
@@ -1,0 +1,8 @@
+package com.auth0.android.guardian.sdk;
+
+public interface RichConsentRequestedDetails {
+    String getAudience();
+    String[] getScope();
+    String getBindingMessage();
+}
+

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
@@ -1,0 +1,43 @@
+package com.auth0.android.guardian.sdk;
+
+import com.auth0.android.guardian.sdk.model.RichConsent;
+import com.auth0.android.guardian.sdk.networking.RequestFactory;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+
+import okhttp3.HttpUrl;
+
+public class RichConsentsAPIClient {
+    private final RequestFactory requestFactory;
+    private final HttpUrl baseUrl;
+
+    RichConsentsAPIClient(RequestFactory requestFactory, HttpUrl baseUrl) {
+        this.requestFactory = requestFactory;
+        this.baseUrl = baseUrl.newBuilder()
+                .addPathSegments("rich-consents")
+                .build();
+    }
+
+    public GuardianAPIRequest<RichConsent> fetch(String consentId, String transactionToken) {
+        Type type = new TypeToken<RichConsent>() {
+        }.getType();
+
+        final HttpUrl url = baseUrl.newBuilder()
+                .addPathSegment("rich-consents")
+                .addPathSegment(consentId)
+                .build();
+
+//        final String dpopAssertion = createProofOfPossessionAssertion(
+//                url,
+//                privateKey,
+//                publicKey,
+//                transactionToken
+//        );
+
+        return requestFactory
+                .<RichConsent>newRequest("GET", url, type)
+                .setHeader("Authorization", "MFA-DPoP ".concat(transactionToken));
+//                .setHeader("MFA-DPoP", dpopAssertion);
+    }
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
@@ -1,22 +1,40 @@
 package com.auth0.android.guardian.sdk;
 
+import static com.auth0.android.guardian.sdk.oauth2.OAuth2AccessToken.getTokenHash;
+
+import android.util.Base64;
+
 import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.networking.RequestFactory;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.reflect.TypeToken;
 
 import java.lang.reflect.Type;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import okhttp3.HttpUrl;
 
 public class RichConsentsAPIClient {
     private final RequestFactory requestFactory;
     private final HttpUrl baseUrl;
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
 
-    RichConsentsAPIClient(RequestFactory requestFactory, HttpUrl baseUrl) {
+    RichConsentsAPIClient(RequestFactory requestFactory, HttpUrl baseUrl, PrivateKey privateKey, PublicKey publicKey) {
         this.requestFactory = requestFactory;
         this.baseUrl = baseUrl.newBuilder()
                 .addPathSegments("rich-consents")
                 .build();
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
     }
 
     public GuardianAPIRequest<RichConsent> fetch(String consentId, String transactionToken) {
@@ -24,20 +42,66 @@ public class RichConsentsAPIClient {
         }.getType();
 
         final HttpUrl url = baseUrl.newBuilder()
-                .addPathSegment("rich-consents")
                 .addPathSegment(consentId)
                 .build();
 
-//        final String dpopAssertion = createProofOfPossessionAssertion(
-//                url,
-//                privateKey,
-//                publicKey,
-//                transactionToken
-//        );
+        final String dpopAssertion = createProofOfPossessionAssertion(
+                url,
+                privateKey,
+                publicKey,
+                transactionToken
+        );
 
         return requestFactory
                 .<RichConsent>newRequest("GET", url, type)
-                .setHeader("Authorization", "MFA-DPoP ".concat(transactionToken));
-//                .setHeader("MFA-DPoP", dpopAssertion);
+                .setHeader("Authorization", "MFA-DPoP ".concat(transactionToken))
+                .setHeader("MFA-DPoP", dpopAssertion);
+    }
+
+    private String createProofOfPossessionAssertion(HttpUrl url, PrivateKey privateKey, PublicKey publicKey, String transactionToken) {
+        long currentTime = new Date().getTime() / 1000L;
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("alg", "RS256");
+        headers.put("typ", "dpop+jwt");
+        headers.put("jwk", exportJWK(publicKey));
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("htu", url.toString());
+        claims.put("htm", "GET");
+        claims.put("ath", getTokenHash(transactionToken));
+        claims.put("jti", UUID.randomUUID().toString());
+        claims.put("iat", currentTime);
+
+        Algorithm alg = Algorithm.RSA256(null, (RSAPrivateKey) privateKey);
+        return JWT.create()
+                .withHeader(headers)
+                .withPayload(claims)
+                .sign(alg);
+    }
+
+    private static Map<String, String> exportJWK(PublicKey publicKey) {
+        if (!(publicKey instanceof RSAPublicKey)) {
+            throw new IllegalArgumentException("The key is not an RSA public key.");
+        }
+
+        RSAPublicKey rsaPublicKey = (RSAPublicKey) publicKey;
+
+        // Extract the modulus and exponent
+        String modulus = base64UrlSafeEncode(rsaPublicKey.getModulus().toByteArray());
+        String exponent = base64UrlSafeEncode(rsaPublicKey.getPublicExponent().toByteArray());
+
+        // Create the JWK structure
+        Map<String, String> jwk = new HashMap<>();
+        jwk.put("kty", "RSA");
+        jwk.put("n", modulus);
+        jwk.put("e", exponent);
+        jwk.put("alg", "RS256");  // You can change this depending on the algorithm you're using
+        jwk.put("use", "sig");    // Use 'sig' for signature verification
+
+        return jwk;
+    }
+
+    private static String base64UrlSafeEncode(byte[] bytes) {
+        return Base64.encodeToString(bytes, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
     }
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
@@ -4,7 +4,6 @@ import static com.auth0.android.guardian.sdk.oauth2.OAuth2AccessToken.getTokenHa
 
 import android.util.Base64;
 
-import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.networking.RequestFactory;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -38,7 +37,7 @@ public class RichConsentsAPIClient {
     }
 
     public GuardianAPIRequest<RichConsent> fetch(String consentId, String transactionToken) {
-        Type type = new TypeToken<RichConsent>() {
+        Type type = new TypeToken<GuardianRichConsent>() {
         }.getType();
 
         final HttpUrl url = baseUrl.newBuilder()

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsent.java
@@ -1,0 +1,8 @@
+package com.auth0.android.guardian.sdk.model;
+
+public class RichConsent {
+    public String id;
+    public RichConsentRequestedDetails requested_details;
+    public String created_at;
+    public String expires_at;
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsent.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsent.java
@@ -1,8 +1,0 @@
-package com.auth0.android.guardian.sdk.model;
-
-public class RichConsent {
-    public String id;
-    public RichConsentRequestedDetails requested_details;
-    public String created_at;
-    public String expires_at;
-}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsentRequestedDetails.java
@@ -1,7 +1,0 @@
-package com.auth0.android.guardian.sdk.model;
-
-public class RichConsentRequestedDetails {
-    public String audience;
-    public String[] scope;
-    public String binding_message;
-}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsentRequestedDetails.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/model/RichConsentRequestedDetails.java
@@ -1,0 +1,7 @@
+package com.auth0.android.guardian.sdk.model;
+
+public class RichConsentRequestedDetails {
+    public String audience;
+    public String[] scope;
+    public String binding_message;
+}

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/networking/Request.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/networking/Request.java
@@ -186,9 +186,9 @@ public class Request<T> implements GuardianAPIRequest<T> {
             final Reader reader = response.body().charStream();
             Type type = new TypeToken<Map<String, Object>>() {}.getType();
             Map<String, Object> error = converter.parse(type, reader);
-            return new GuardianException(error);
+            return new GuardianException(error, response.code());
         } catch (Exception e) {
-            return new GuardianException("Error parsing server error response", e);
+            return new GuardianException("Error parsing server error response", response.code(), e);
         }
     }
 }

--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/oauth2/OAuth2AccessToken.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/oauth2/OAuth2AccessToken.java
@@ -1,0 +1,20 @@
+package com.auth0.android.guardian.sdk.oauth2;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class OAuth2AccessToken {
+    public static String getTokenHash(String token) {
+        MessageDigest digest = null;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        byte[] hash = digest.digest(token.getBytes());
+        return android.util.Base64.encodeToString(hash,
+                android.util.Base64.URL_SAFE |
+                        android.util.Base64.NO_WRAP |
+                        android.util.Base64.NO_PADDING);
+    }
+}

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -26,7 +26,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Base64;
 
-import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.networking.Callback;
 import com.auth0.android.guardian.sdk.utils.MockCallback;
 import com.auth0.android.guardian.sdk.utils.MockWebService;

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianAPIClientTest.java
@@ -26,6 +26,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Base64;
 
+import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.networking.Callback;
 import com.auth0.android.guardian.sdk.utils.MockCallback;
 import com.auth0.android.guardian.sdk.utils.MockWebService;
@@ -501,6 +502,25 @@ public class GuardianAPIClientTest {
         assertThat(authorization, Matchers.startsWith("Bearer "));
         String jwt = authorization.split("Bearer ")[1];
         verifyBasicJWT(jwt);
+    }
+
+    @Test
+    public void shouldCreateValidRichConsentsAPI() throws Exception {
+        GuardianAPIClient apiClient = new GuardianAPIClient.Builder()
+                .url(Uri.parse(mockAPI.getDomain() + "appliance-mfa"))
+                .build();
+        String consentId = "cns_00000001";
+
+        mockAPI.willReturnRichConsent(consentId, "https://api", "openid", "test");
+
+        final MockCallback<RichConsent> callback = new MockCallback<>();
+
+        apiClient.richConsents(keyPair.getPrivate(), keyPair.getPublic())
+                .fetch(consentId, "token")
+                .start(callback);
+
+        RecordedRequest request = mockAPI.takeRequest();
+        assertThat(request.getPath(), is(equalTo(String.format("/rich-consents/%s", consentId))));
     }
 
     private Map<String, Object> bodyFromRequest(RecordedRequest request) throws IOException {

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianEnrollmentTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianEnrollmentTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import java.security.PrivateKey;
+import java.security.PublicKey;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -50,6 +51,9 @@ public class GuardianEnrollmentTest {
     @Mock
     PrivateKey privateKey;
 
+    @Mock
+    PublicKey publicKey;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -60,7 +64,7 @@ public class GuardianEnrollmentTest {
         CurrentDevice device = new CurrentDevice(DEVICE_GCM_TOKEN, DEVICE_NAME, DEVICE_LOCAL_IDENTIFIER);
 
         Enrollment enrollment = new GuardianEnrollment(USER, PERIOD, DIGITS, ALGORITHM,
-                SECRET_BASE32, DEVICE_ID, device, DEVICE_TOKEN, privateKey);
+                SECRET_BASE32, DEVICE_ID, device, DEVICE_TOKEN, privateKey, publicKey);
 
         assertThat(enrollment.getUserId(), is(equalTo(USER)));
         assertThat(enrollment.getPeriod(), is(equalTo(PERIOD)));
@@ -73,5 +77,6 @@ public class GuardianEnrollmentTest {
         assertThat(enrollment.getNotificationToken(), is(equalTo(DEVICE_GCM_TOKEN)));
         assertThat(enrollment.getDeviceToken(), is(equalTo(DEVICE_TOKEN)));
         assertThat(enrollment.getSigningKey(), is(sameInstance(privateKey)));
+        assertThat(enrollment.getPublicKey(), is(sameInstance(publicKey)));
     }
 }

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianExceptionTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianExceptionTest.java
@@ -27,11 +27,11 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 public class GuardianExceptionTest {
 
@@ -157,6 +157,39 @@ public class GuardianExceptionTest {
         assertThat(exception.isEnrollmentNotFound(), is(equalTo(false)));
         assertThat(exception.isEnrollmentTransactionNotFound(), is(equalTo(false)));
         assertThat(exception.isLoginTransactionNotFound(), is(equalTo(true)));
+    }
+
+    @Test
+    public void testIsResourceNotFound() throws Exception {
+        GuardianException exception = new GuardianException(createErrorMap("not_found"));
+
+        assertThat(exception.getErrorCode(), is(equalTo("not_found")));
+
+        assertThat(exception.isResourceNotFound(), is(equalTo(true)));
+
+        assertThat(exception.isInvalidOTP(), is(equalTo(false)));
+        assertThat(exception.isInvalidToken(), is(equalTo(false)));
+        assertThat(exception.isEnrollmentNotFound(), is(equalTo(false)));
+        assertThat(exception.isEnrollmentTransactionNotFound(), is(equalTo(false)));
+        assertThat(exception.isLoginTransactionNotFound(), is(equalTo(false)));
+    }
+
+    @Test
+    public void testIsResourceNotFoundWhenStatusCodeIs404() throws Exception {
+
+        GuardianException exception = new GuardianException(createErrorMap("error"), 404);
+
+        assertThat(exception.getErrorCode(), is(equalTo("error")));
+        assertThat(exception.getStatusCode(), is(equalTo(404)));
+
+        assertThat(exception.isResourceNotFound(), is(equalTo(true)));
+
+        assertThat(exception.isInvalidOTP(), is(equalTo(false)));
+        assertThat(exception.isInvalidToken(), is(equalTo(false)));
+        assertThat(exception.isEnrollmentNotFound(), is(equalTo(false)));
+        assertThat(exception.isEnrollmentTransactionNotFound(), is(equalTo(false)));
+        assertThat(exception.isLoginTransactionNotFound(), is(equalTo(false)));
+
     }
 
     private Map<String, Object> createErrorMap(String errorCode) {

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
@@ -39,8 +39,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 
 import android.net.Uri;
 
-import com.auth0.android.guardian.sdk.model.RichConsent;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,16 +49,12 @@ import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPrivateCrtKey;
-import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Map;
 
 @RunWith(RobolectricTestRunner.class)

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/GuardianTest.java
@@ -121,7 +121,7 @@ public class GuardianTest {
         currentDevice = new CurrentDevice(GCM_TOKEN, DEVICE_NAME, DEVICE_IDENTIFIER);
 
         enrollment = new GuardianEnrollment(USER, PERIOD, DIGITS, ALGORITHM, SECRET_BASE32,
-                DEVICE_ID, currentDevice, DEVICE_TOKEN, privateKey);
+                DEVICE_ID, currentDevice, DEVICE_TOKEN, privateKey, publicKey);
 
         when(apiClient.device(DEVICE_ID, DEVICE_TOKEN))
                 .thenReturn(deviceApiClient);
@@ -191,7 +191,7 @@ public class GuardianTest {
         when(richConsentsAPIClient.fetch(TRANSACTION_LINKING_ID, TRANSACTION_TOKEN))
                 .thenReturn(mockRequest);
 
-        GuardianAPIRequest<RichConsent> request = guardian.fetchConsent(notification, enrollment, publicKey);
+        GuardianAPIRequest<RichConsent> request = guardian.fetchConsent(notification, enrollment);
 
         verify(apiClient).richConsents(privateKey, publicKey);
         verify(richConsentsAPIClient).fetch(TRANSACTION_LINKING_ID, TRANSACTION_TOKEN);
@@ -208,7 +208,7 @@ public class GuardianTest {
         RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
 
         GuardianEnrollment enrollment = new GuardianEnrollment(USER, PERIOD, DIGITS, ALGORITHM, SECRET_BASE32,
-                DEVICE_ID, currentDevice, DEVICE_TOKEN, signingKey);
+                DEVICE_ID, currentDevice, DEVICE_TOKEN, signingKey, publicKey);
 
         when(apiClient.richConsents(any(PrivateKey.class), any(PublicKey.class)))
                 .thenReturn(richConsentsAPIClient);

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
@@ -1,0 +1,88 @@
+package com.auth0.android.guardian.sdk;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.auth0.android.guardian.sdk.model.RichConsent;
+import com.auth0.android.guardian.sdk.networking.Callback;
+import com.auth0.android.guardian.sdk.networking.RequestFactory;
+import com.auth0.android.guardian.sdk.utils.MockWebService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.RecordedRequest;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23, manifest = Config.NONE)
+public class RichConsentsAPIClientTest {
+    private static final String CONSENT_ID = "cns_00000000001";
+    private static final String SCOPE = "openid";
+    private static final String AUDIENCE = "https://t3st.auth0.com/userinfo";
+    private static final String BINDING_MESSAGE = "abc-123";
+    // TODO: actual token
+    private static final String TRANSACTION_TOKEN = "token";
+
+    private MockWebService mockAPI;
+    private RichConsentsAPIClient richConsentsAPIClient;
+
+    @Mock
+    Callback<RichConsent> fetchCallback;
+
+    @Before
+    public void setUp() throws Exception {
+        openMocks(this);
+        mockAPI = new MockWebService();
+        final String domain = mockAPI.getDomain();
+
+        Gson gson = new GsonBuilder()
+                .create();
+
+        RequestFactory requestFactory = new RequestFactory(gson, new OkHttpClient());
+
+        richConsentsAPIClient = new RichConsentsAPIClient(requestFactory, HttpUrl.parse(domain));
+    }
+
+    @Test
+    public void shouldFetchRichConsent() throws Exception {
+        mockAPI.willReturnRichConsent(CONSENT_ID, AUDIENCE, SCOPE, BINDING_MESSAGE);
+
+        richConsentsAPIClient
+                .fetch(CONSENT_ID, TRANSACTION_TOKEN)
+                .start(fetchCallback);
+
+        RecordedRequest request = mockAPI.takeRequest();
+
+        assertThat(request.getPath(), is(equalTo(String.format("/rich-consents/%s", CONSENT_ID))));
+        assertThat(request.getMethod(), is(equalTo("GET")));
+        assertThat(request.getHeader("Authorization"), is(equalTo("MFA-DPoP " + TRANSACTION_TOKEN)));
+//         TODO: calculate actual assertion
+//        assertThat(request.getHeader("MFA-DPoP"), is(equalTo("MFA-DPoP " + "assertion")));
+
+        ArgumentCaptor<RichConsent> onSuccessCaptor = ArgumentCaptor.forClass(RichConsent.class);
+        verify(fetchCallback, timeout(100)).onSuccess(onSuccessCaptor.capture());
+
+        RichConsent capturedRichConsent = onSuccessCaptor.getValue();
+        assertThat(capturedRichConsent.id, is(equalTo(CONSENT_ID)));
+        assertThat(capturedRichConsent.requested_details.audience, is(equalTo(AUDIENCE)));
+        assertThat(capturedRichConsent.requested_details.scope, is(equalTo(SCOPE)));
+        assertThat(capturedRichConsent.requested_details.binding_message, is(equalTo(BINDING_MESSAGE)));
+
+        verifyNoMoreInteractions(fetchCallback);
+        assertThat(true, is(equalTo(true)));
+    }
+}

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.MockitoAnnotations.openMocks;
 
-import com.auth0.android.guardian.sdk.model.RichConsent;
 import com.auth0.android.guardian.sdk.networking.Callback;
 import com.auth0.android.guardian.sdk.networking.RequestFactory;
 import com.auth0.android.guardian.sdk.utils.MockWebService;
@@ -90,14 +89,14 @@ public class RichConsentsAPIClientTest {
         assertThat(dpopAssertion, is(notNullValue()));
         verifyDPoPAssertion(dpopAssertion);
 
-        ArgumentCaptor<RichConsent> onSuccessCaptor = ArgumentCaptor.forClass(RichConsent.class);
+        ArgumentCaptor<RichConsent> onSuccessCaptor = ArgumentCaptor.forClass(GuardianRichConsent.class);
         verify(fetchCallback, timeout(100)).onSuccess(onSuccessCaptor.capture());
 
         RichConsent capturedRichConsent = onSuccessCaptor.getValue();
-        assertThat(capturedRichConsent.id, is(equalTo(CONSENT_ID)));
-        assertThat(capturedRichConsent.requested_details.audience, is(equalTo(AUDIENCE)));
-        assertThat(capturedRichConsent.requested_details.scope[0], is(equalTo(SCOPE)));
-        assertThat(capturedRichConsent.requested_details.binding_message, is(equalTo(BINDING_MESSAGE)));
+        assertThat(capturedRichConsent.getId(), is(equalTo(CONSENT_ID)));
+        assertThat(capturedRichConsent.getRequestedDetails().getAudience(), is(equalTo(AUDIENCE)));
+        assertThat(capturedRichConsent.getRequestedDetails().getScope()[0], is(equalTo(SCOPE)));
+        assertThat(capturedRichConsent.getRequestedDetails().getBindingMessage(), is(equalTo(BINDING_MESSAGE)));
 
         verifyNoMoreInteractions(fetchCallback);
         assertThat(true, is(equalTo(true)));

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import android.net.Uri;
+
 import com.auth0.android.guardian.sdk.networking.Callback;
 import com.auth0.android.guardian.sdk.networking.RequestFactory;
 import com.auth0.android.guardian.sdk.utils.MockWebService;
@@ -66,9 +68,8 @@ public class RichConsentsAPIClientTest {
         RequestFactory requestFactory = new RequestFactory(gson, new OkHttpClient());
 
         richConsentsAPIClient = new RichConsentsAPIClient(requestFactory,
-                HttpUrl.parse(domain),
-                keyPair.getPrivate(),
-                keyPair.getPublic());
+                Uri.parse(domain),
+                new ClientInfo());
     }
 
     @Test
@@ -76,7 +77,7 @@ public class RichConsentsAPIClientTest {
         mockAPI.willReturnRichConsent(CONSENT_ID, AUDIENCE, SCOPE, BINDING_MESSAGE);
 
         richConsentsAPIClient
-                .fetch(CONSENT_ID, TRANSACTION_TOKEN)
+                .fetch(CONSENT_ID, TRANSACTION_TOKEN, keyPair.getPrivate(), keyPair.getPublic())
                 .start(fetchCallback);
 
         RecordedRequest request = mockAPI.takeRequest();

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/utils/MockWebService.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/utils/MockWebService.java
@@ -128,13 +128,13 @@ public class MockWebService {
     public MockWebService willReturnRichConsent(String id, String audience, String scope, String binding_message) {
         String json = "" +
                 "{" +
-                "   \"id\": \""+id+"\"" +
-                "  ,\"created_at\": \""+ Instant.now().minusSeconds(10).getEpochSecond() +"\"" +
-                "  ,\"expires_at\": \""+ Instant.now().plusSeconds(290).getEpochSecond() +"\"" +
+                "   \"id\": \"" + id + "\"" +
+                "  ,\"created_at\": " + Instant.now().minusSeconds(10).getEpochSecond() +
+                "  ,\"expires_at\": " + Instant.now().plusSeconds(290).getEpochSecond() +
                 "  ,\"requested_details\": {" +
-                "       \"audience\": \""+audience+"\"" +
-                "      ,\"scope\": "+scope +
-                "      ,\"binding_message\": "+binding_message +
+                "       \"audience\": \"" + audience + "\"" +
+                "      ,\"scope\": [\"" + scope + "\"]" +
+                "      ,\"binding_message\": \"" + binding_message + "\"" +
                 "   }" +
                 "}";
         server.enqueue(responseWithJSON(json, 200));

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/utils/MockWebService.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/utils/MockWebService.java
@@ -23,6 +23,7 @@
 package com.auth0.android.guardian.sdk.utils;
 
 import java.io.IOException;
+import java.time.Instant;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -121,6 +122,22 @@ public class MockWebService {
                 "   }") +
                 "}";
         server.enqueue(responseWithJSON(json, 201));
+        return this;
+    }
+
+    public MockWebService willReturnRichConsent(String id, String audience, String scope, String binding_message) {
+        String json = "" +
+                "{" +
+                "   \"id\": \""+id+"\"" +
+                "  ,\"created_at\": \""+ Instant.now().minusSeconds(10).getEpochSecond() +"\"" +
+                "  ,\"expires_at\": \""+ Instant.now().plusSeconds(290).getEpochSecond() +"\"" +
+                "  ,\"requested_details\": {" +
+                "       \"audience\": \""+audience+"\"" +
+                "      ,\"scope\": "+scope +
+                "      ,\"binding_message\": "+binding_message +
+                "   }" +
+                "}";
+        server.enqueue(responseWithJSON(json, 200));
         return this;
     }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Adds fetch rich consent record capability to guardian sdk.


### References


### Testing

1. Run the sample app
2. Enroll to MFA
3. Initiate a CIBA authentication request for the enrolled user
4. Verify the consent details are displayed


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
