### PR TITLE
Expose getAPIClient()

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/Guardian.java
@@ -171,7 +171,7 @@ public class Guardian {
         return richConsentsAPIClient.fetch(notification.getTransactionLinkingId(), notification.getTransactionToken(), enrollment.getSigningKey(), enrollment.getPublicKey());
     }
 
-    GuardianAPIClient getAPIClient() {
+    public GuardianAPIClient getAPIClient() {
         return guardianAPIClient;
     }
 


### PR DESCRIPTION
Expose `getAPIClient()` as a public method as it should be