### PR TITLE
Create github action for publishing

### DIFF
--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -1,0 +1,43 @@
+name: Publish release to Java
+
+inputs:
+  java-version:
+    required: true
+  ossr-username:
+    required: true
+  ossr-token:
+    required: true
+  signing-key:
+    required: true
+  signing-password:
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Java
+      shell: bash
+      run: |
+        curl -s "https://get.sdkman.io" | bash
+        source "/home/runner/.sdkman/bin/sdkman-init.sh"
+        sdk list java
+        sdk install java ${{ inputs.java-version }} && sdk default java ${{ inputs.java-version }}
+        export JAVA_HOME=${SDKMAN_DIR}/candidates/java/current
+        echo "JAVA_HOME is set to $JAVA_HOME"
+    - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # pin@1.1.0
+      env:
+        JAVA_HOME: ${{ env.JAVA_HOME }}
+
+    - name: Publish Android/Java Packages to Maven
+      shell: bash
+      run: ./gradlew publish -PisSnapshot=false --stacktrace
+      env:
+        JAVA_HOME: ${{ env.JAVA_HOME }}
+        MAVEN_USERNAME: ${{ inputs.ossr-username }}
+        MAVEN_PASSWORD: ${{ inputs.ossr-token }}
+        SIGNING_KEY: ${{ inputs.signing-key}}
+        SIGNING_PASSWORD: ${{ inputs.signing-password}}

--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -1,4 +1,4 @@
-name: Manually Publish Java Release
+name: Publish Java Release
 
 on:
   workflow_dispatch: # Allows manual triggering
@@ -18,10 +18,45 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Verify version against branch name
+        shell: bash
+        run: |
+          BRANCH_NAME="${{ github.ref_name }}"
+          echo "Current branch: $BRANCH_NAME"
+
+          if [[ "$BRANCH_NAME" == "master" ]]; then
+            echo "Skipping version check for master branch."
+            exit 0
+          fi
+
+          if [[ ! -f .version ]]; then
+            echo "Error: .version file not found!"
+            exit 1
+          fi
+
+          # Read the version file and trim whitespace
+          VERSION_FROM_FILE=$(cat .version | xargs)
+          
+          if [[ -z "$VERSION_FROM_FILE" ]]; then
+            echo "Error: .version file is empty or contains only whitespace!"
+            exit 1
+          fi
+          
+          echo "Version from .version file: '$VERSION_FROM_FILE'"
+          echo "Branch name: '$BRANCH_NAME'"
+
+          if [[ "$VERSION_FROM_FILE" != "$BRANCH_NAME" ]]; then
+            echo "Error: mismatched version file against branch. Version file: '$VERSION_FROM_FILE', Branch: '$BRANCH_NAME'"
+            exit 1
+          else
+            echo "Version file content matches branch name. Proceeding..."
+          fi
+
       - name: Setup Java 17
         id: setup_java
         shell: bash
         run: |
+          echo "Starting Java setup..."
           curl -s "https://get.sdkman.io" | bash
           # Ensure SDKMAN environment variables are available for the current shell and subsequent steps
           # Using $HOME is generally more portable than /home/runner
@@ -55,8 +90,7 @@ jobs:
         run: ./gradlew publish -PisSnapshot=false --stacktrace
         env:
           JAVA_HOME: ${{ env.JAVA_HOME_PATH }}
-          # These should match the names of your GitHub secrets
           MAVEN_USERNAME: ${{ secrets.OSSR_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSR_TOKEN }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }} # This might be a base64 encoded key
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }} 
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/actions/maven-publish/action.yml
+++ b/.github/actions/maven-publish/action.yml
@@ -1,43 +1,62 @@
-name: Publish release to Java
+name: Manually Publish Java Release
 
-inputs:
-  java-version:
-    required: true
-  ossr-username:
-    required: true
-  ossr-token:
-    required: true
-  signing-key:
-    required: true
-  signing-password:
-    required: true
+on:
+  workflow_dispatch: # Allows manual triggering
+    # No inputs needed here if java-version is fixed and others are secrets
+    # If you still want to override java-version occasionally, you could add:
+    # inputs:
+    #   java-version-override:
+    #     description: 'Optional: Specify Java version for SDKMAN (e.g., 17.0.11-tem). Defaults to Java 17.'
+    #     required: false
+    #     default: '17.0.11-tem'
 
-runs:
-  using: composite
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release # Optional: configure an environment if you use environment-specific secrets or protection rules
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Setup Java 17
+        id: setup_java
+        shell: bash
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          # Ensure SDKMAN environment variables are available for the current shell and subsequent steps
+          # Using $HOME is generally more portable than /home/runner
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          
+          # List available Java versions (optional, for debugging)
+          sdk list java
+          
+          # Install and set Java 17 (e.g., Temurin 17.0.11)
+          # You can replace '17.0.11-tem' with the specific Java 17 distribution and version you prefer from 'sdk list java'
+          JAVA_VERSION_TO_INSTALL="17.0.11-tem" 
+          # If you added java-version-override input:
+          # JAVA_VERSION_TO_INSTALL="${{ github.event.inputs.java-version-override || '17.0.11-tem' }}"
+          
+          sdk install java "$JAVA_VERSION_TO_INSTALL"
+          sdk default java "$JAVA_VERSION_TO_INSTALL"
+          
+          INSTALLED_JAVA_HOME=$(sdk home java "$JAVA_VERSION_TO_INSTALL")
+          echo "JAVA_HOME_PATH=$INSTALLED_JAVA_HOME" >> $GITHUB_ENV
+          echo "Successfully set up Java $JAVA_VERSION_TO_INSTALL"
+          echo "JAVA_HOME is now $INSTALLED_JAVA_HOME"
+          java -version
 
-    - name: Setup Java
-      shell: bash
-      run: |
-        curl -s "https://get.sdkman.io" | bash
-        source "/home/runner/.sdkman/bin/sdkman-init.sh"
-        sdk list java
-        sdk install java ${{ inputs.java-version }} && sdk default java ${{ inputs.java-version }}
-        export JAVA_HOME=${SDKMAN_DIR}/candidates/java/current
-        echo "JAVA_HOME is set to $JAVA_HOME"
-    - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # pin@1.1.0
-      env:
-        JAVA_HOME: ${{ env.JAVA_HOME }}
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # pin@1.1.0
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_PATH }}
 
-    - name: Publish Android/Java Packages to Maven
-      shell: bash
-      run: ./gradlew publish -PisSnapshot=false --stacktrace
-      env:
-        JAVA_HOME: ${{ env.JAVA_HOME }}
-        MAVEN_USERNAME: ${{ inputs.ossr-username }}
-        MAVEN_PASSWORD: ${{ inputs.ossr-token }}
-        SIGNING_KEY: ${{ inputs.signing-key}}
-        SIGNING_PASSWORD: ${{ inputs.signing-password}}
+      - name: Publish Android/Java Packages to Maven
+        shell: bash
+        run: ./gradlew publish -PisSnapshot=false --stacktrace
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_PATH }}
+          # These should match the names of your GitHub secrets
+          MAVEN_USERNAME: ${{ secrets.OSSR_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSR_TOKEN }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }} # This might be a base64 encoded key
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Build and Test
+
+on:
+  merge_group:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  unit:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup
+
+      - run: ./gradlew clean test jacocoTestReport lint --continue --console=plain --max-workers=1 --no-daemon
+
+      - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # pin@4.5.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Guardian SDK for Android
 
-[![CircleCI](https://img.shields.io/circleci/project/github/auth0/Guardian.Android.svg)](https://circleci.com/gh/auth0/Guardian.Android)
 [![Coverage Status](https://img.shields.io/codecov/c/github/auth0/Guardian.Android/master.svg)](https://codecov.io/github/auth0/Guardian.Android)
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
 [![Maven Central](https://img.shields.io/maven-central/v/com.auth0.android/guardian.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.auth0.android%22%20AND%20a%3A%22guardian%22)


### PR DESCRIPTION


### Description
This change adds a github action that is to be triggered manually to create an initial build of the SDK and push it to sonatype. 

### References
https://auth0team.atlassian.net/browse/MFA-3549
### Testing
Testing is done via running github actions
