### PR TITLE
[FGI-1209] Modify Guardian.Android SDK to handle being passed a url with a .guardian. subdomain

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
@@ -34,6 +34,8 @@ public class RichConsentsAPIClient {
     private final HttpUrl baseUrl;
     private final ClientInfo clientInfo;
 
+    private static final String CONSENT_PATH = "rich-consents";
+
 
     RichConsentsAPIClient(RequestFactory requestFactory, Uri url, ClientInfo clientInfo) {
         this.requestFactory = requestFactory;
@@ -120,10 +122,21 @@ public class RichConsentsAPIClient {
                 .setHeader("MFA-DPoP", dpopAssertion);
     }
 
-    private HttpUrl buildBaseUrl(Uri url) {
+    public static HttpUrl buildBaseUrl(Uri url) {
         HttpUrl httpUrl = HttpUrl.parse(url.toString());
+        if (httpUrl == null) {
+            throw new NullPointerException("Base uri cannot be null");
+        }
+
+        String host = httpUrl.host();
+
+        if (host.endsWith("auth0.com")) {
+            host = host.replace(".guardian", "");
+        }
+
         return httpUrl.newBuilder()
-                .addPathSegments("rich-consents")
+                .host(host)
+                .addPathSegments(CONSENT_PATH)
                 .build();
     }
 }


### PR DESCRIPTION
Modify the Guardian SDKs to be more “forgiving” when using the https://{tenant}.guardian.{region}.auth0.com url to call the consent api functions and do the URL manipulation to remove the .guardian. sub-domain