### PR TITLE
Handle case where consent client is created with an /appliance-mfa url

### DIFF
--- a/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
+++ b/guardian/src/main/java/com/auth0/android/guardian/sdk/RichConsentsAPIClient.java
@@ -19,6 +19,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -128,14 +129,19 @@ public class RichConsentsAPIClient {
             throw new NullPointerException("Base uri cannot be null");
         }
 
-        String host = httpUrl.host();
+        HttpUrl.Builder newUrlbuilder = httpUrl.newBuilder();
 
+        String host = httpUrl.host();
         if (host.endsWith("auth0.com")) {
-            host = host.replace(".guardian", "");
+            newUrlbuilder.host(host.replace(".guardian", ""));
         }
 
-        return httpUrl.newBuilder()
-                .host(host)
+        int applianceMfaPathIndex = httpUrl.pathSegments().indexOf("appliance-mfa");
+        if (applianceMfaPathIndex >= 0) {
+            newUrlbuilder.removePathSegment(applianceMfaPathIndex);
+        }
+
+        return newUrlbuilder
                 .addPathSegments(CONSENT_PATH)
                 .build();
     }

--- a/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
+++ b/guardian/src/test/java/com/auth0/android/guardian/sdk/RichConsentsAPIClientTest.java
@@ -208,6 +208,16 @@ public class RichConsentsAPIClientTest {
                         "should handle custom domain url with guardian subdomain",
                         "https://guardian.custom-domain.com",
                         "https://guardian.custom-domain.com/rich-consents"
+                ),
+                new TestCase(
+                        "should handle canonical domain url with appliance-mfa path",
+                        "https://samples.eu.auth0.com/appliance-mfa",
+                        "https://samples.eu.auth0.com/rich-consents"
+                ),
+                new TestCase(
+                        "should handle custom domain url with appliance-mfa path",
+                        "https://custom-domain.com/appliance-mfa",
+                        "https://custom-domain.com/rich-consents"
                 )
         );
 


### PR DESCRIPTION
Allows usage of older style guardian urls consisting of the tenant domain with an "appliance-mfa" path when using RichConsentsAPIClient. This allow for backwards compatibility that clients still using those style of urls when setting up guardian without them having to make changes.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
