### PR TITLE
Update gradle publishing method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.12.2'
         classpath 'com.google.gms:google-services:4.4.2'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx12800M
 org.gradle.configureondemand=true
 
-
-android.useAndroidX=true
 GROUP=com.auth0.android
 POM_ARTIFACT_ID=guardian
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.9-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id "com.vanniktech.maven.publish" version "0.34.0"
 }
 
 
@@ -38,8 +39,44 @@ android {
     namespace 'com.auth0.android.guardian.sdk'
 }
 
-apply from: rootProject.file('gradle/maven-publish.gradle')
+mavenPublishing {
+    publishToMavenCentral(false)
+    signAllPublications()
 
+    coordinates(
+            project.group.toString(),
+            findProperty("POM_ARTIFACT_ID")?.toString(),
+            project.version.toString()
+    )
+
+    pom {
+        name.set(findProperty("POM_NAME")?.toString())
+        description.set(findProperty("POM_DESCRIPTION")?.toString())
+        url.set(findProperty("POM_URL")?.toString())
+
+        licenses {
+            license {
+                name.set(findProperty("POM_LICENCE_NAME")?.toString())
+                url.set(findProperty("POM_LICENCE_URL")?.toString())
+                distribution.set(findProperty("POM_LICENCE_DIST")?.toString())
+            }
+        }
+
+        developers {
+            developer {
+                id.set(findProperty("POM_DEVELOPER_ID")?.toString())
+                name.set(findProperty("POM_DEVELOPER_NAME")?.toString())
+                email.set(findProperty("POM_DEVELOPER_EMAIL")?.toString())
+            }
+        }
+
+        scm {
+            url.set(findProperty("POM_URL")?.toString())
+            connection.set(findProperty("POM_SCM_CONNECTION")?.toString())
+            developerConnection.set(findProperty("POM_SCM_DEV_CONNECTION")?.toString())
+        }
+    }
+}
 
 dependencies {
     // Annotations (@NonNull etc)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'Guardian.Android'
 
 include ':app'


### PR DESCRIPTION

### Description

The previous gradle publish method is now incompatible given that the OSSRH has been [sunset](https://central.sonatype.org/news/20250326_ossrh_sunset/)

We now provide the correct method to publish a build via:
```./gradlew :guardian:publishToMavenCentral````
### References
https://auth0team.atlassian.net/browse/MFA-4054

### Testing
When running the provided command, we see the build in Maven Central:
<img width="1131" height="204" alt="sonatype_upload" src="https://github.com/user-attachments/assets/bc14d5f4-cd14-4373-ba8f-984915cbea61" />


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
