### PR TITLE
Bump java-jwt to 4.6.0 and pin Jackson 2.22.1 to fix CVEs

### DIFF
--- a/guardian/build.gradle
+++ b/guardian/build.gradle
@@ -88,7 +88,9 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.squareup.okhttp3:logging-interceptor'
     // JWT signing/verification
-    implementation 'com.auth0:java-jwt:4.5.1'
+    implementation 'com.auth0:java-jwt:4.6.0'
+    // Pin patched Jackson (fixes CVEs in the version pulled transitively by java-jwt)
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.22.1')
 
     testImplementation 'com.squareup.okhttp3:mockwebserver'
     // Mockito


### PR DESCRIPTION
## Summary

The transitive Jackson dependency pulled in via `com.auth0:java-jwt` is flagged with multiple security advisories (HIGH severity in both `jackson-databind` and `jackson-core`). The current `master` (0.11.0) uses `java-jwt:4.5.1`, which pulls **Jackson 2.21.0** — still vulnerable.

This bumps `java-jwt` to **4.6.0** and pins **`jackson-bom:2.22.1`** so both `jackson-core` and `jackson-databind` resolve to the fully patched **2.22.1**.

## Why the BOM pin is needed

| Config | Jackson | Open advisories (per OSV) |
|---|---|---|
| `java-jwt:4.5.1` (current master / 0.11.0) | 2.21.0 | ❌ 12 |
| `java-jwt:4.6.0` alone | 2.22.0 | ❌ 3 (incl. HIGH `GHSA-r7wm-3cxj-wff9`) |
| `java-jwt:4.6.0` + `jackson-bom:2.22.1` | **2.22.1** | ✅ 0 |

## Verification

- `./gradlew :guardian:dependencies` confirms `jackson-core` and `jackson-databind` both resolve to `2.22.1`.
- `./gradlew :guardian:test` passes (28 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)