### PR TITLE
Create release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.11.0](https://github.com/auth0/Guardian.Android/tree/0.11.0) (2026-07-23)
+[Full Changelog](https://github.com/auth0/Guardian.Android/compare/0.10.2...0.11.0)
+
+**Changed**
+- Handle case where consent client is created with an /appliance-mfa url (see [PR](https://github.com/auth0/Guardian.Android/pull/138))
+- Bump com.auth0:java-jwt to 4.6.0 and pin com.fasterxml.jackson:jackson-bom to 2.22.1 to fix CVEs (see [PR](https://github.com/auth0/Guardian.Android/pull/146))
+
 ## [0.10.2](https://github.com/auth0/Guardian.Android/tree/0.10.2) (2025-08-08)
 [Full Changelog](https://github.com/auth0/Guardian.Android/compare/0.10.1...0.10.2)
 


### PR DESCRIPTION
Adds the `CHANGELOG.md` entry for the 0.11.0 release.

### Context
This release ran out of the usual order, so this PR only carries the CHANGELOG:

- **`.version`** was already bumped to `0.11.0` in #144, rather than in a dedicated release PR.
- **Maven Central** already has `0.11.0`, published 2026-07-23. Its POM (`java-jwt 4.6.0`, `jackson-bom 2.22.1`) matches `c994035`.
- **Tag `0.11.0`** and the GitHub release were created on `c994035` so the tag matches the published artifact exactly. This CHANGELOG commit therefore lands one commit after the tag.

### Included changes
- #138 — handle consent client created with an `/appliance-mfa` url
- #146 — bump `java-jwt` to 4.6.0, pin `jackson-bom` to 2.22.1 to fix CVEs

CI-only changes (#139, #141, #145) are omitted, following the 0.10.2 entry's precedent of listing user-facing changes only.

### Note
`0.10.2` was tagged and released on GitHub but never reached Maven Central (404; Central goes 0.9.1 → 0.11.0). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)